### PR TITLE
Milestone 2: Core Modules

### DIFF
--- a/src/devbox/onepassword.py
+++ b/src/devbox/onepassword.py
@@ -2,7 +2,47 @@
 
 from __future__ import annotations
 
+import subprocess
 
-def get_secret(reference: str) -> str:
-    """Resolve a 1Password secret reference via the op CLI."""
-    raise NotImplementedError
+from devbox.exceptions import OnePasswordError
+
+
+def get_secret(reference: str, timeout: int = 10) -> str:
+    """Resolve a single op:// reference via `op read`. Returns the secret value.
+
+    Raises OnePasswordError on failure.
+    """
+    try:
+        result = subprocess.run(
+            ["op", "read", reference],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        raise OnePasswordError("1Password CLI (op) is not installed") from None
+    except subprocess.TimeoutExpired:
+        raise OnePasswordError(
+            "1Password CLI timed out — is the vault locked?"
+        ) from None
+
+    if result.returncode != 0:
+        raise OnePasswordError(result.stderr.strip())
+
+    return result.stdout.strip()
+
+
+def resolve_env_vars(env_vars: dict[str, str]) -> dict[str, str]:
+    """Take a dict of env vars, resolve any op:// values via get_secret.
+
+    Non-op:// values are passed through unchanged.
+    Returns a new dict with all values resolved.
+    Raises OnePasswordError if any op:// reference fails.
+    """
+    resolved: dict[str, str] = {}
+    for key, value in env_vars.items():
+        if value.startswith("op://"):
+            resolved[key] = get_secret(value)
+        else:
+            resolved[key] = value
+    return resolved

--- a/src/devbox/presets.py
+++ b/src/devbox/presets.py
@@ -2,38 +2,88 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from devbox.exceptions import PresetError
+from devbox.naming import validate_name
+
 PRESETS_DIR = Path.home() / ".dotfiles-private" / "devbox" / "presets"
 
-# Preset schema:
-# {
-#   "name": "",
-#   "description": "",
-#   "provider": "",
-#   "aws_profile": "",
-#   "github_account": "",
-#   "node_version": "lts",
-#   "python_version": "3.12",
-#   "brew_extras": [],
-#   "npm_globals": [],
-#   "pip_globals": [],
-#   "mcp_profile": "",
-#   "env_vars": {}
-# }
+
+class Preset(BaseModel):
+    """Pydantic model for a devbox preset."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = 1
+    name: str
+    description: str
+    provider: str
+    aws_profile: str = ""
+    github_account: str
+    color_scheme: str = "gruvbox"
+    node_version: str = "lts"
+    python_version: str = "3.12"
+    brew_extras: list[str] = []
+    npm_globals: list[str] = []
+    pip_globals: list[str] = []
+    mcp_profile: str = ""
+    env_vars: dict[str, str] = {}
 
 
-def load_preset(name: str) -> dict[str, Any]:
-    """Load a preset by name from the presets directory."""
-    raise NotImplementedError
+def load_preset(name: str, presets_dir: Path | None = None) -> Preset:
+    """Load a preset by name from the presets directory.
+
+    Raises :exc:`PresetError` if the file is missing, contains invalid JSON,
+    or fails validation against the Preset model.
+    """
+    try:
+        validate_name(name)
+    except ValueError as exc:
+        raise PresetError(str(exc)) from exc
+
+    directory = presets_dir if presets_dir is not None else PRESETS_DIR
+    preset_path = directory / f"{name}.json"
+
+    if not preset_path.exists():
+        raise PresetError(f"Preset file not found: {preset_path}")
+
+    try:
+        raw = preset_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PresetError(f"Failed to read preset file: {exc}") from exc
+
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PresetError(f"Invalid JSON in preset {name!r}: {exc}") from exc
+
+    return validate_preset(data)
 
 
-def validate_preset(data: dict[str, Any]) -> None:
-    """Validate a preset dict against the expected schema. Raises on error."""
-    raise NotImplementedError
+def validate_preset(data: dict[str, Any]) -> Preset:
+    """Validate a dict against the Preset model.
+
+    Returns the validated :class:`Preset` if valid, raises :exc:`PresetError` otherwise.
+    """
+    try:
+        return Preset.model_validate(data)
+    except ValidationError as exc:
+        raise PresetError(f"Preset validation failed: {exc}") from exc
 
 
-def list_presets() -> list[str]:
-    """Return names of all available presets."""
-    raise NotImplementedError
+def list_presets(presets_dir: Path | None = None) -> list[str]:
+    """Return sorted list of preset names (filenames without ``.json``).
+
+    Returns an empty list if the directory does not exist.
+    """
+    directory = presets_dir if presets_dir is not None else PRESETS_DIR
+
+    if not directory.is_dir():
+        return []
+
+    return sorted(p.stem for p in directory.glob("*.json"))

--- a/src/devbox/registry.py
+++ b/src/devbox/registry.py
@@ -2,30 +2,127 @@
 
 from __future__ import annotations
 
+import contextlib
+import json
+import os
+import tempfile
+from enum import StrEnum
 from pathlib import Path
-from typing import Any
+
+from pydantic import BaseModel
+
+from devbox.exceptions import RegistryError
 
 REGISTRY_PATH = Path.home() / ".devbox" / "registry.json"
 
-# Registry schema:
-# {
-#   "devboxes": [
-#     {
-#       "name": "devbox1",
-#       "preset": "splash-data",
-#       "created": "2025-03-12",
-#       "last_seen": "2025-03-12T10:00:00Z",
-#       "github_key_id": "12345678"
-#     }
-#   ]
-# }
+
+class DevboxStatus(StrEnum):
+    """Lifecycle status for a devbox."""
+
+    CREATING = "creating"
+    READY = "ready"
+    NUKING = "nuking"
 
 
-def load_registry() -> dict[str, Any]:
-    """Load the registry from disk. Returns empty structure if missing."""
-    raise NotImplementedError
+class RegistryEntry(BaseModel):
+    """A single devbox entry in the registry."""
+
+    name: str
+    preset: str
+    status: DevboxStatus = DevboxStatus.CREATING
+    created: str  # ISO date
+    last_seen: str | None = None  # ISO datetime
+    github_key_id: str | None = None
 
 
-def save_registry(data: dict[str, Any]) -> None:
-    """Write the registry back to disk."""
-    raise NotImplementedError
+class Registry(BaseModel):
+    """Top-level registry schema."""
+
+    version: int = 1
+    devboxes: list[RegistryEntry] = []
+
+
+def load_registry(path: Path | None = None) -> Registry:
+    """Load the registry from disk. Returns empty registry if file missing."""
+    registry_path = path or REGISTRY_PATH
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not registry_path.exists():
+        return Registry()
+
+    text = registry_path.read_text(encoding="utf-8")
+    if not text.strip():
+        return Registry()
+
+    data = json.loads(text)
+    version = data.get("version", 1)
+    if version != 1:
+        raise RegistryError(f"Unsupported registry version: {version}")
+
+    return Registry.model_validate(data)
+
+
+def save_registry(registry: Registry, path: Path | None = None) -> None:
+    """Atomic write: write to temp file in same dir, then os.replace."""
+    registry_path = path or REGISTRY_PATH
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+    content = registry.model_dump_json(indent=2) + "\n"
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(registry_path.parent),
+        prefix=".registry_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, str(registry_path))
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def add_entry(entry: RegistryEntry, path: Path | None = None) -> None:
+    """Append entry to devboxes list. Raise RegistryError if duplicate name."""
+    registry = load_registry(path)
+    for existing in registry.devboxes:
+        if existing.name == entry.name:
+            raise RegistryError(f"Duplicate devbox name: {entry.name}")
+    registry.devboxes.append(entry)
+    save_registry(registry, path)
+
+
+def remove_entry(name: str, path: Path | None = None) -> None:
+    """Remove entry by name. Raise RegistryError if not found."""
+    registry = load_registry(path)
+    for i, existing in enumerate(registry.devboxes):
+        if existing.name == name:
+            registry.devboxes.pop(i)
+            save_registry(registry, path)
+            return
+    raise RegistryError(f"Devbox not found: {name}")
+
+
+def find_entry(name: str, path: Path | None = None) -> RegistryEntry | None:
+    """Lookup by name, return RegistryEntry or None."""
+    registry = load_registry(path)
+    for existing in registry.devboxes:
+        if existing.name == name:
+            return existing
+    return None
+
+
+def update_entry(name: str, path: Path | None = None, **fields: object) -> None:
+    """Partial update by name. Raise RegistryError if not found."""
+    registry = load_registry(path)
+    for existing in registry.devboxes:
+        if existing.name == name:
+            for key, value in fields.items():
+                if not hasattr(existing, key):
+                    raise RegistryError(f"Invalid field: {key}")
+                setattr(existing, key, value)
+            save_registry(registry, path)
+            return
+    raise RegistryError(f"Devbox not found: {name}")

--- a/tests/test_onepassword.py
+++ b/tests/test_onepassword.py
@@ -1,0 +1,114 @@
+"""Tests for the 1Password CLI wrapper."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from devbox.exceptions import OnePasswordError
+from devbox.onepassword import get_secret, resolve_env_vars
+
+
+class TestGetSecret:
+    def test_calls_subprocess_correctly(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.onepassword.subprocess.run")
+        mock_run.return_value = MagicMock(returncode=0, stdout="secret-value")
+
+        get_secret("op://vault/item/field", timeout=15)
+
+        mock_run.assert_called_once_with(
+            ["op", "read", "op://vault/item/field"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+    def test_returns_stripped_output(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.onepassword.subprocess.run")
+        mock_run.return_value = MagicMock(returncode=0, stdout="secret-value\n  ")
+
+        result = get_secret("op://vault/item/field")
+
+        assert result == "secret-value"
+
+    def test_raises_when_op_not_found(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.onepassword.subprocess.run")
+        mock_run.side_effect = FileNotFoundError
+
+        with pytest.raises(OnePasswordError, match=r"1Password CLI .* is not installed"):
+            get_secret("op://vault/item/field")
+
+    def test_raises_on_nonzero_exit(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.onepassword.subprocess.run")
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr="item not found\n"
+        )
+
+        with pytest.raises(OnePasswordError, match="item not found"):
+            get_secret("op://vault/item/field")
+
+    def test_raises_on_timeout(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.onepassword.subprocess.run")
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="op", timeout=10)
+
+        with pytest.raises(OnePasswordError, match="timed out"):
+            get_secret("op://vault/item/field")
+
+    def test_uses_default_timeout(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.onepassword.subprocess.run")
+        mock_run.return_value = MagicMock(returncode=0, stdout="val")
+
+        get_secret("op://vault/item/field")
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["timeout"] == 10
+
+
+class TestResolveEnvVars:
+    def test_resolves_op_values(self, mocker: MockerFixture) -> None:
+        mock_get = mocker.patch("devbox.onepassword.get_secret", return_value="resolved")
+
+        result = resolve_env_vars({"TOKEN": "op://vault/item/field"})
+
+        assert result == {"TOKEN": "resolved"}
+        mock_get.assert_called_once_with("op://vault/item/field")
+
+    def test_passes_through_non_op_values(self, mocker: MockerFixture) -> None:
+        mocker.patch("devbox.onepassword.get_secret")
+
+        result = resolve_env_vars({"PATH": "/usr/bin", "HOME": "/home/user"})
+
+        assert result == {"PATH": "/usr/bin", "HOME": "/home/user"}
+
+    def test_handles_mixed_dict(self, mocker: MockerFixture) -> None:
+        mock_get = mocker.patch("devbox.onepassword.get_secret", return_value="secret")
+
+        result = resolve_env_vars({
+            "PLAIN": "hello",
+            "SECRET": "op://vault/item/field",
+            "ALSO_PLAIN": "world",
+        })
+
+        assert result == {
+            "PLAIN": "hello",
+            "SECRET": "secret",
+            "ALSO_PLAIN": "world",
+        }
+        mock_get.assert_called_once_with("op://vault/item/field")
+
+    def test_raises_on_failed_resolution(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "devbox.onepassword.get_secret",
+            side_effect=OnePasswordError("bad ref"),
+        )
+
+        with pytest.raises(OnePasswordError, match="bad ref"):
+            resolve_env_vars({"TOKEN": "op://vault/bad/ref"})
+
+    def test_empty_dict_returns_empty(self) -> None:
+        result = resolve_env_vars({})
+
+        assert result == {}

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,159 @@
+"""Tests for devbox preset loading and validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devbox.exceptions import PresetError
+from devbox.presets import Preset, list_presets, load_preset, validate_preset
+
+VALID_PRESET: dict[str, Any] = {
+    "name": "test-preset",
+    "description": "A test preset",
+    "provider": "local",
+    "github_account": "octocat",
+}
+
+
+def _write_preset(directory: Path, name: str, data: dict[str, Any]) -> Path:
+    """Write a preset JSON file and return its path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{name}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestLoadPreset:
+    """load_preset reads and validates a preset file."""
+
+    def test_valid_preset_loads(self, tmp_path: Path) -> None:
+        _write_preset(tmp_path, "my-preset", VALID_PRESET)
+        preset = load_preset("my-preset", presets_dir=tmp_path)
+        assert isinstance(preset, Preset)
+        assert preset.name == "test-preset"
+        assert preset.description == "A test preset"
+        assert preset.provider == "local"
+        assert preset.github_account == "octocat"
+
+    def test_missing_file_raises_preset_error(self, tmp_path: Path) -> None:
+        with pytest.raises(PresetError, match="not found"):
+            load_preset("no-such-preset", presets_dir=tmp_path)
+
+    def test_invalid_json_raises_preset_error(self, tmp_path: Path) -> None:
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "bad-json.json").write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(PresetError, match="Invalid JSON"):
+            load_preset("bad-json", presets_dir=tmp_path)
+
+    def test_missing_required_fields_raises_preset_error(self, tmp_path: Path) -> None:
+        _write_preset(tmp_path, "incomplete", {"name": "incomplete"})
+        with pytest.raises(PresetError, match="validation failed"):
+            load_preset("incomplete", presets_dir=tmp_path)
+
+    def test_unknown_fields_raises_preset_error(self, tmp_path: Path) -> None:
+        data = {**VALID_PRESET, "unknown_field": "surprise"}
+        _write_preset(tmp_path, "extra-field", data)
+        with pytest.raises(PresetError, match="validation failed"):
+            load_preset("extra-field", presets_dir=tmp_path)
+
+    def test_invalid_name_raises_preset_error(self, tmp_path: Path) -> None:
+        with pytest.raises(PresetError, match="kebab-case"):
+            load_preset("Bad_Name", presets_dir=tmp_path)
+
+    def test_empty_name_raises_preset_error(self, tmp_path: Path) -> None:
+        with pytest.raises(PresetError, match="empty"):
+            load_preset("", presets_dir=tmp_path)
+
+
+class TestPresetDefaults:
+    """Preset model has correct default values."""
+
+    def test_defaults_applied(self) -> None:
+        preset = Preset(**VALID_PRESET)
+        assert preset.version == 1
+        assert preset.aws_profile == ""
+        assert preset.color_scheme == "gruvbox"
+        assert preset.node_version == "lts"
+        assert preset.python_version == "3.12"
+        assert preset.brew_extras == []
+        assert preset.npm_globals == []
+        assert preset.pip_globals == []
+        assert preset.mcp_profile == ""
+        assert preset.env_vars == {}
+
+    def test_all_fields_correct_types(self) -> None:
+        full_data: dict[str, Any] = {
+            "version": 2,
+            "name": "full",
+            "description": "Full preset",
+            "provider": "aws",
+            "aws_profile": "my-profile",
+            "github_account": "user",
+            "color_scheme": "catppuccin",
+            "node_version": "20",
+            "python_version": "3.13",
+            "brew_extras": ["htop", "jq"],
+            "npm_globals": ["typescript"],
+            "pip_globals": ["ruff"],
+            "mcp_profile": "default",
+            "env_vars": {"FOO": "bar"},
+        }
+        preset = Preset(**full_data)
+        assert preset.version == 2
+        assert isinstance(preset.brew_extras, list)
+        assert isinstance(preset.env_vars, dict)
+        assert preset.env_vars["FOO"] == "bar"
+
+
+class TestValidatePreset:
+    """validate_preset validates dicts against the Preset model."""
+
+    def test_valid_data_returns_preset(self) -> None:
+        result = validate_preset(VALID_PRESET)
+        assert isinstance(result, Preset)
+        assert result.name == "test-preset"
+
+    def test_missing_required_field_raises_preset_error(self) -> None:
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset({"name": "only-name"})
+
+    def test_unknown_field_raises_preset_error(self) -> None:
+        data = {**VALID_PRESET, "bogus": True}
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+    def test_wrong_type_raises_preset_error(self) -> None:
+        data = {**VALID_PRESET, "version": "not-an-int"}
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+
+class TestListPresets:
+    """list_presets returns sorted preset names."""
+
+    def test_returns_sorted_names(self, tmp_path: Path) -> None:
+        _write_preset(tmp_path, "zulu", VALID_PRESET)
+        _write_preset(tmp_path, "alpha", VALID_PRESET)
+        _write_preset(tmp_path, "mike", VALID_PRESET)
+        result = list_presets(presets_dir=tmp_path)
+        assert result == ["alpha", "mike", "zulu"]
+
+    def test_returns_empty_list_for_missing_dir(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        result = list_presets(presets_dir=missing)
+        assert result == []
+
+    def test_ignores_non_json_files(self, tmp_path: Path) -> None:
+        _write_preset(tmp_path, "valid", VALID_PRESET)
+        (tmp_path / "readme.txt").write_text("not a preset", encoding="utf-8")
+        result = list_presets(presets_dir=tmp_path)
+        assert result == ["valid"]
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        result = list_presets(presets_dir=tmp_path)
+        assert result == []

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,224 @@
+"""Tests for the devbox registry module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devbox.exceptions import RegistryError
+from devbox.registry import (
+    DevboxStatus,
+    Registry,
+    RegistryEntry,
+    add_entry,
+    find_entry,
+    load_registry,
+    remove_entry,
+    save_registry,
+    update_entry,
+)
+
+
+def _registry_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.json"
+
+
+def _make_entry(
+    name: str = "dev1",
+    preset: str = "splash-data",
+    status: DevboxStatus = DevboxStatus.CREATING,
+    created: str = "2025-03-12",
+) -> RegistryEntry:
+    return RegistryEntry(name=name, preset=preset, status=status, created=created)
+
+
+class TestLoadRegistry:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        reg = load_registry(_registry_path(tmp_path))
+        assert reg.version == 1
+        assert reg.devboxes == []
+
+    def test_empty_file_returns_empty(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        p.write_text("")
+        reg = load_registry(p)
+        assert reg.devboxes == []
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        p = tmp_path / "nested" / "dir" / "registry.json"
+        reg = load_registry(p)
+        assert p.parent.is_dir()
+        assert reg.devboxes == []
+
+    def test_loads_valid_data(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        data = {
+            "version": 1,
+            "devboxes": [
+                {"name": "dev1", "preset": "splash-data", "created": "2025-03-12"}
+            ],
+        }
+        p.write_text(json.dumps(data))
+        reg = load_registry(p)
+        assert len(reg.devboxes) == 1
+        assert reg.devboxes[0].name == "dev1"
+        assert reg.devboxes[0].status == DevboxStatus.CREATING
+
+    def test_unsupported_version_raises(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        p.write_text(json.dumps({"version": 99, "devboxes": []}))
+        with pytest.raises(RegistryError, match="Unsupported registry version: 99"):
+            load_registry(p)
+
+
+class TestSaveRegistry:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        entry = _make_entry()
+        reg = Registry(devboxes=[entry])
+        save_registry(reg, p)
+        loaded = load_registry(p)
+        assert loaded == reg
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        p = tmp_path / "nested" / "registry.json"
+        save_registry(Registry(), p)
+        assert p.exists()
+
+    def test_atomic_write_no_leftover_temp(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        save_registry(Registry(), p)
+        # No temp files should remain
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].name == "registry.json"
+
+    def test_file_content_is_valid_json(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        entry = _make_entry()
+        save_registry(Registry(devboxes=[entry]), p)
+        data = json.loads(p.read_text())
+        assert data["version"] == 1
+        assert len(data["devboxes"]) == 1
+        assert data["devboxes"][0]["name"] == "dev1"
+
+
+class TestAddEntry:
+    def test_adds_entry(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1"), p)
+        reg = load_registry(p)
+        assert len(reg.devboxes) == 1
+        assert reg.devboxes[0].name == "dev1"
+
+    def test_adds_multiple_entries(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1"), p)
+        add_entry(_make_entry("dev2"), p)
+        reg = load_registry(p)
+        assert len(reg.devboxes) == 2
+
+    def test_duplicate_name_raises(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1"), p)
+        with pytest.raises(RegistryError, match="Duplicate devbox name: dev1"):
+            add_entry(_make_entry("dev1"), p)
+
+
+class TestRemoveEntry:
+    def test_removes_entry(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1"), p)
+        add_entry(_make_entry("dev2"), p)
+        remove_entry("dev1", p)
+        reg = load_registry(p)
+        assert len(reg.devboxes) == 1
+        assert reg.devboxes[0].name == "dev2"
+
+    def test_missing_name_raises(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        with pytest.raises(RegistryError, match="Devbox not found: nope"):
+            remove_entry("nope", p)
+
+
+class TestFindEntry:
+    def test_finds_existing(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1"), p)
+        result = find_entry("dev1", p)
+        assert result is not None
+        assert result.name == "dev1"
+
+    def test_returns_none_for_missing(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        assert find_entry("nope", p) is None
+
+
+class TestUpdateEntry:
+    def test_updates_fields(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1"), p)
+        update_entry("dev1", p, status=DevboxStatus.READY, last_seen="2025-03-12T10:00:00Z")
+        result = find_entry("dev1", p)
+        assert result is not None
+        assert result.status == DevboxStatus.READY
+        assert result.last_seen == "2025-03-12T10:00:00Z"
+
+    def test_missing_name_raises(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        with pytest.raises(RegistryError, match="Devbox not found: nope"):
+            update_entry("nope", p, status=DevboxStatus.READY)
+
+    def test_invalid_field_raises(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1"), p)
+        with pytest.raises(RegistryError, match="Invalid field: bogus"):
+            update_entry("dev1", p, bogus="value")
+
+
+class TestStatusTransitions:
+    def test_creating_to_ready(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1", status=DevboxStatus.CREATING), p)
+        update_entry("dev1", p, status=DevboxStatus.READY)
+        result = find_entry("dev1", p)
+        assert result is not None
+        assert result.status == DevboxStatus.READY
+
+    def test_ready_to_nuking(self, tmp_path: Path) -> None:
+        p = _registry_path(tmp_path)
+        add_entry(_make_entry("dev1", status=DevboxStatus.READY), p)
+        update_entry("dev1", p, status=DevboxStatus.NUKING)
+        result = find_entry("dev1", p)
+        assert result is not None
+        assert result.status == DevboxStatus.NUKING
+
+
+class TestModels:
+    def test_devbox_status_values(self) -> None:
+        assert DevboxStatus.CREATING.value == "creating"
+        assert DevboxStatus.READY.value == "ready"
+        assert DevboxStatus.NUKING.value == "nuking"
+
+    def test_registry_entry_defaults(self) -> None:
+        entry = RegistryEntry(name="x", preset="p", created="2025-01-01")
+        assert entry.status == DevboxStatus.CREATING
+        assert entry.last_seen is None
+        assert entry.github_key_id is None
+
+    def test_registry_defaults(self) -> None:
+        reg = Registry()
+        assert reg.version == 1
+        assert reg.devboxes == []
+
+    def test_registry_entry_serialization(self) -> None:
+        entry = _make_entry(
+            name="dev1",
+        )
+        data = entry.model_dump()
+        assert data["name"] == "dev1"
+        assert data["status"] == "creating"
+        restored = RegistryEntry.model_validate(data)
+        assert restored == entry


### PR DESCRIPTION
## Summary
- **Registry module** (`registry.py`): Pydantic v2 models (`DevboxStatus`, `RegistryEntry`, `Registry`), CRUD operations (`add_entry`, `remove_entry`, `find_entry`, `update_entry`), atomic write via temp+rename, schema version checking — 25 tests
- **Preset loading** (`presets.py`): Pydantic model with `extra="forbid"` for strict validation, `load_preset`, `validate_preset`, `list_presets`, `PresetError` handling — 17 tests
- **1Password wrapper** (`onepassword.py`): `get_secret` via `op read`, `resolve_env_vars` for bulk `op://` resolution, error handling (not installed, locked, timeout) — 11 tests

## Issues
Closes #3, closes #4, closes #5

## Test plan
- [x] `ruff check .` passes
- [x] `mypy src/` passes (strict, 14 source files)
- [x] `pytest` passes (117 tests total, 53 new)
- [ ] CI workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)