### PR TITLE
refactor: use SSH for brew/globals installs in refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add concurrency control to CI workflows
 
 ### Added
-- `devbox refresh <name>` and `devbox refresh --all` to push current dotfiles/config to existing devboxes without destroying state, with `--with-brew` and `--with-globals` opt-in flags for slower full reinstalls (#49)
+- `devbox refresh <name>` and `devbox refresh --all` to push current dotfiles/config and reinstall preset `brew_extras` on existing devboxes without destroying state. Runs entirely over SSH as the devbox user (no host sudo). `--with-globals` opt-in reinstalls `npm_globals`/`pip_globals`. Loadout Brewfile changes require `rebuild`. (#49, #51)
 - SPDX license headers and copyright notices on all source files
 - CODE_OF_CONDUCT.md (Contributor Covenant v2.1)
 - GitHub issue templates (bug report, feature request)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ devbox rebuild mybox
 # Push current dotfiles/preset config to an existing devbox (preserves state)
 devbox refresh mybox
 devbox refresh --all
-devbox refresh mybox --with-brew --with-globals  # also reinstall brew/npm/pip (slow)
+devbox refresh mybox --with-globals  # also reinstall npm/pip globals
 
 # Permanently destroy
 devbox nuke mybox
@@ -35,19 +35,20 @@ devbox nuke mybox
 
 ### `refresh` vs `rebuild`
 
-- **`refresh`** SSHes into the existing devbox and re-runs `loadout update`,
-  pulling the latest dotfiles. Shell history, uncommitted work, and local
-  files are preserved. Fast (~30s/box). The devbox must be in `ready` state
-  (run `devbox list` to check); refreshing a `creating`/`nuking` box is
-  refused.
-- **Edited a preset?** Plain `refresh` is enough for *dotfile* preset fields
-  (loadout orgs, env vars, etc.). To pick up changes to `brew_extras`, run
-  `refresh --with-brew`. For `npm_globals`/`pip_globals`, use
-  `refresh --with-globals`. These are slow (15-30 min/box) because the
-  per-devbox `~/.homebrew` prefix has no bottles and compiles from source.
+- **`refresh`** SSHes into the existing devbox, re-runs `loadout update`
+  to pull the latest dotfiles, and reinstalls the preset's `brew_extras`.
+  Shell history, uncommitted work, and local files are preserved. The
+  devbox must be in `ready` state (run `devbox list` to check);
+  refreshing a `creating`/`nuking` box is refused.
+- **Edited a preset?** Plain `refresh` picks up dotfile-level changes
+  (loadout orgs, env vars) and `brew_extras` automatically. For
+  `npm_globals` / `pip_globals`, pass `--with-globals`. Changes to the
+  loadout Brewfile itself aren't picked up by refresh — `rebuild` the
+  devbox for that (the per-devbox `~/.homebrew` prefix has no bottles and
+  compiles from source, 30+ min).
 - **`rebuild`** nukes and recreates the devbox from scratch. Destroys all
-  in-devbox state. Use when bootstrap itself changed, or when the box is
-  irrecoverably broken.
+  in-devbox state. Use when bootstrap itself changed, the loadout
+  Brewfile changed, or the box is irrecoverably broken.
 
 ## Presets
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -106,12 +106,13 @@ devbox3       default         2025-03-10   SSH timeout  ❌ unreachable
 
 ### `devbox refresh`
 
-SSH into the existing devbox and re-run `loadout update --skip-brew --skip-globals` to pull current dotfiles and preset config. In-devbox state (shell history, uncommitted work, local files) is preserved. Refuses to run on devboxes that aren't in `ready` state.
+SSH into the existing devbox, run `loadout update --skip-brew --skip-globals` to pull current dotfiles, and reinstall the preset's `brew_extras`. In-devbox state (shell history, uncommitted work, local files) is preserved. Refuses to run on devboxes that aren't in `ready` state. All steps run as the devbox user over SSH — no host sudo, works in non-interactive shells.
+
+The loadout Brewfile itself is never re-run by refresh (it compiles from source at the non-standard `~/.homebrew` prefix, 30+ min) — use `rebuild` if it changes.
 
 Flags:
 
-- `--with-brew` — also drop `--skip-brew` (run loadout Brewfile) and reinstall preset `brew_extras`. Slow (15-30 min/box) because the per-devbox `~/.homebrew` prefix has no bottles.
-- `--with-globals` — also drop `--skip-globals` and reinstall preset `npm_globals` / `pip_globals`.
+- `--with-globals` — also reinstall preset `npm_globals` / `pip_globals`.
 - `--all` — iterate every `ready` devbox in the registry. Failures are collected and reported at the end; one failed box does not abort the rest.
 
 ### `devbox rebuild`

--- a/src/devbox/bootstrap.py
+++ b/src/devbox/bootstrap.py
@@ -104,6 +104,32 @@ def build_ssh_base(preset: Preset, username: str) -> list[str]:
     ]
 
 
+def refresh_shell_env(home_dir: Path, preset: Preset, username: str) -> None:
+    """Push .zshenv and .zprofile to an existing devbox over SSH.
+
+    Ensures PATH is correct for interactive login shells — without
+    .zprofile, macOS ``path_helper`` leaves the parent's
+    ``/opt/homebrew/bin`` ahead of the devbox's per-user
+    ``~/.homebrew/bin``, so parent binaries shadow devbox installs.
+
+    Raises :exc:`BootstrapError` on failure.
+    """
+    from devbox.zshrc import ZPROFILE_CONTENT, ZSHENV_CONTENT
+
+    _validate_username(username)
+    ssh_base = build_ssh_base(preset, username)
+    for filename, content in (("/.zshenv", ZSHENV_CONTENT), ("/.zprofile", ZPROFILE_CONTENT)):
+        _run_checked(
+            [
+                *ssh_base,
+                f"cat > ~{filename} << 'DEVBOX_SHELL_ENV_EOF'\n{content}DEVBOX_SHELL_ENV_EOF\n"
+                f"&& chmod 0644 ~{filename}",
+            ],
+            error_prefix=f"write ~{filename}",
+            timeout=10,
+        )
+
+
 def refresh_dotfiles(
     home_dir: Path,
     preset: Preset,

--- a/src/devbox/bootstrap.py
+++ b/src/devbox/bootstrap.py
@@ -89,7 +89,7 @@ def _resolve_loadout_bin() -> str:
     return loadout_bin
 
 
-def _ssh_base(preset: Preset, username: str) -> list[str]:
+def build_ssh_base(preset: Preset, username: str) -> list[str]:
     """Return the SSH command prefix for connecting to a devbox as *username*.
 
     Returns a fresh list each call so callers can safely splat/append.
@@ -122,7 +122,7 @@ def refresh_dotfiles(
         return
 
     loadout_bin = _resolve_loadout_bin()
-    ssh_base = _ssh_base(preset, username)
+    ssh_base = build_ssh_base(preset, username)
     q_home = shlex.quote(str(home_dir))
 
     flags = []
@@ -163,7 +163,7 @@ def run_loadout(home_dir: Path, preset: Preset, username: str) -> None:
 
     # Resolve loadout bin early so we fail fast before slow clone steps.
     _resolve_loadout_bin()
-    ssh_base = _ssh_base(preset, username)
+    ssh_base = build_ssh_base(preset, username)
 
     # Clone dotfiles repos via SSH (private repos need SSH auth).
     acct = preset.github_account
@@ -387,12 +387,15 @@ def install_homebrew(home_dir: Path, username: str) -> None:
 def _wrap_as_user(inner_cmd: str, username: str, ssh_base: list[str] | None) -> list[str]:
     """Wrap *inner_cmd* so it runs as the devbox user.
 
-    When *ssh_base* is given, execute via SSH (no host sudo needed).
-    Otherwise, run locally via ``sudo -u <username> bash -c ...`` — used
-    during initial bootstrap before the devbox has SSH access set up.
+    When *ssh_base* is given, execute via SSH (no host sudo needed). The
+    inner command is wrapped as ``bash -c <quoted>`` on the remote so
+    execution parity with the ``sudo -u`` path doesn't depend on the
+    devbox user's login shell. Otherwise, run locally via
+    ``sudo -u <username> bash -c ...`` — used during initial bootstrap
+    before the devbox has SSH access set up.
     """
     if ssh_base is not None:
-        return [*ssh_base, inner_cmd]
+        return [*ssh_base, f"bash -c {shlex.quote(inner_cmd)}"]
     return ["sudo", "-u", username, "bash", "-c", inner_cmd]
 
 
@@ -706,9 +709,16 @@ def _run_checked(
 
     if result.returncode != 0:
         stderr_tail = (result.stderr or "").strip()[-500:]
+        # SSH returns 255 for any connection-layer failure (auth, host key,
+        # network). Flag it so operators don't confuse it with a package
+        # install failure.
+        rc_label = (
+            "SSH connection failure (exit 255)"
+            if result.returncode == 255 and cmd and cmd[0] == "ssh"
+            else f"exit code {result.returncode}"
+        )
         raise BootstrapError(
-            f"{error_prefix}: exit code {result.returncode}"
-            + (f" — {stderr_tail}" if stderr_tail else "")
+            f"{error_prefix}: {rc_label}" + (f" — {stderr_tail}" if stderr_tail else "")
         )
 
     return result

--- a/src/devbox/bootstrap.py
+++ b/src/devbox/bootstrap.py
@@ -108,11 +108,13 @@ def refresh_dotfiles(
     home_dir: Path,
     preset: Preset,
     username: str,
-    *,
-    with_brew: bool = False,
-    with_globals: bool = False,
 ) -> None:
-    """Run ``loadout update`` over SSH to refresh dotfiles on an existing devbox.
+    """Run ``loadout update --skip-brew --skip-globals`` over SSH to refresh dotfiles.
+
+    Always skips brew bundle and globals — preset-level brew_extras and
+    globals are installed separately by the caller, and the loadout
+    Brewfile is only run on rebuild (compiles from source at the
+    non-standard ``~/.homebrew`` prefix, 30+ min).
 
     Skips if no loadout_orgs are configured in the preset.
     Raises :exc:`BootstrapError` on failure.
@@ -125,18 +127,6 @@ def refresh_dotfiles(
     ssh_base = build_ssh_base(preset, username)
     q_home = shlex.quote(str(home_dir))
 
-    flags = []
-    if not with_brew:
-        flags.append("--skip-brew")
-    if not with_globals:
-        flags.append("--skip-globals")
-    flag_str = (" " + " ".join(flags)) if flags else ""
-
-    # Brew bundle at the non-standard ~/.homebrew prefix has no bottles, so
-    # it compiles from source and can take 15-30 min — hence the longer
-    # timeout when --with-brew is requested.
-    timeout = 1800 if with_brew else 180
-
     _run_checked(
         [
             *ssh_base,
@@ -144,10 +134,10 @@ def refresh_dotfiles(
             f"HOMEBREW_CELLAR={q_home}/.homebrew/Cellar "
             f"HOMEBREW_REPOSITORY={q_home}/.homebrew "
             f"PATH={q_home}/.homebrew/bin:{q_home}/.homebrew/sbin:$PATH "
-            f"&& {shlex.quote(loadout_bin)} update{flag_str}",
+            f"&& {shlex.quote(loadout_bin)} update --skip-brew --skip-globals",
         ],
         error_prefix="loadout update",
-        timeout=timeout,
+        timeout=180,
     )
 
 

--- a/src/devbox/bootstrap.py
+++ b/src/devbox/bootstrap.py
@@ -384,8 +384,29 @@ def install_homebrew(home_dir: Path, username: str) -> None:
     )
 
 
-def install_brew_extras(home_dir: Path, packages: list[str], username: str) -> None:
+def _wrap_as_user(inner_cmd: str, username: str, ssh_base: list[str] | None) -> list[str]:
+    """Wrap *inner_cmd* so it runs as the devbox user.
+
+    When *ssh_base* is given, execute via SSH (no host sudo needed).
+    Otherwise, run locally via ``sudo -u <username> bash -c ...`` — used
+    during initial bootstrap before the devbox has SSH access set up.
+    """
+    if ssh_base is not None:
+        return [*ssh_base, inner_cmd]
+    return ["sudo", "-u", username, "bash", "-c", inner_cmd]
+
+
+def install_brew_extras(
+    home_dir: Path,
+    packages: list[str],
+    username: str,
+    *,
+    ssh_base: list[str] | None = None,
+) -> None:
     """Install extra Homebrew packages into the devbox user's per-devbox Homebrew.
+
+    Pass *ssh_base* to run via SSH instead of ``sudo -u`` (required for
+    ``devbox refresh`` in non-interactive shells).
 
     Raises :exc:`BootstrapError` on failure.
     """
@@ -399,19 +420,15 @@ def install_brew_extras(home_dir: Path, packages: list[str], username: str) -> N
     q_prefix = shlex.quote(str(brew_prefix))
     q_brew = shlex.quote(str(brew_bin))
     q_packages = " ".join(shlex.quote(p) for p in packages)
+    inner = (
+        f"export HOME={q_home} "
+        f"HOMEBREW_PREFIX={q_prefix} "
+        f"HOMEBREW_CELLAR={q_prefix}/Cellar "
+        f"HOMEBREW_REPOSITORY={q_prefix} "
+        f"&& {q_brew} install {q_packages}"
+    )
     _run_checked(
-        [
-            "sudo",
-            "-u",
-            username,
-            "bash",
-            "-c",
-            f"export HOME={q_home} "
-            f"HOMEBREW_PREFIX={q_prefix} "
-            f"HOMEBREW_CELLAR={q_prefix}/Cellar "
-            f"HOMEBREW_REPOSITORY={q_prefix} "
-            f"&& {q_brew} install {q_packages}",
-        ],
+        _wrap_as_user(inner, username, ssh_base),
         error_prefix="brew extras install",
         timeout=_BREW_TIMEOUT,
     )
@@ -421,8 +438,12 @@ def install_npm_globals(
     home_dir: Path,
     packages: list[str],
     username: str,
+    *,
+    ssh_base: list[str] | None = None,
 ) -> None:
     """Install global npm packages as the devbox user.
+
+    Pass *ssh_base* to run via SSH instead of ``sudo -u``.
 
     Raises :exc:`BootstrapError` on failure.
     """
@@ -434,16 +455,12 @@ def install_npm_globals(
     q_home = shlex.quote(str(home_dir))
     q_nvm = shlex.quote(str(nvm_dir))
     q_packages = " ".join(shlex.quote(p) for p in packages)
+    inner = (
+        f"export HOME={q_home} && export NVM_DIR={q_nvm} "
+        f"&& . {q_nvm}/nvm.sh && npm install -g {q_packages}"
+    )
     _run_checked(
-        [
-            "sudo",
-            "-u",
-            username,
-            "bash",
-            "-c",
-            f"export HOME={q_home} && export NVM_DIR={q_nvm} "
-            f"&& . {q_nvm}/nvm.sh && npm install -g {q_packages}",
-        ],
+        _wrap_as_user(inner, username, ssh_base),
         error_prefix="npm globals install",
         timeout=_TOOL_TIMEOUT,
     )
@@ -453,8 +470,12 @@ def install_pip_globals(
     home_dir: Path,
     packages: list[str],
     username: str,
+    *,
+    ssh_base: list[str] | None = None,
 ) -> None:
     """Install global pip packages as the devbox user.
+
+    Pass *ssh_base* to run via SSH instead of ``sudo -u``.
 
     Raises :exc:`BootstrapError` on failure.
     """
@@ -468,17 +489,13 @@ def install_pip_globals(
     q_pyenv_root = shlex.quote(str(pyenv_root))
     q_pyenv_bin = shlex.quote(str(pyenv_bin))
     q_packages = " ".join(shlex.quote(p) for p in packages)
+    inner = (
+        f"export HOME={q_home} && export PYENV_ROOT={q_pyenv_root} "
+        f'&& eval "$({q_pyenv_bin} init -)" '
+        f"&& pip install {q_packages}"
+    )
     _run_checked(
-        [
-            "sudo",
-            "-u",
-            username,
-            "bash",
-            "-c",
-            f"export HOME={q_home} && export PYENV_ROOT={q_pyenv_root} "
-            f'&& eval "$({q_pyenv_bin} init -)" '
-            f"&& pip install {q_packages}",
-        ],
+        _wrap_as_user(inner, username, ssh_base),
         error_prefix="pip globals install",
         timeout=_TOOL_TIMEOUT,
     )

--- a/src/devbox/bootstrap.py
+++ b/src/devbox/bootstrap.py
@@ -122,8 +122,9 @@ def refresh_shell_env(home_dir: Path, preset: Preset, username: str) -> None:
         _run_checked(
             [
                 *ssh_base,
-                f"cat > ~{filename} << 'DEVBOX_SHELL_ENV_EOF'\n{content}DEVBOX_SHELL_ENV_EOF\n"
-                f"&& chmod 0644 ~{filename}",
+                f"cat > ~{filename} << 'DEVBOX_SHELL_ENV_EOF'\n"
+                f"{content}DEVBOX_SHELL_ENV_EOF\n"
+                f"chmod 0644 ~{filename}",
             ],
             error_prefix=f"write ~{filename}",
             timeout=10,

--- a/src/devbox/cli.py
+++ b/src/devbox/cli.py
@@ -94,26 +94,17 @@ def rebuild(name: str) -> None:
 @click.argument("name", required=False)
 @click.option("--all", "all_", is_flag=True, default=False, help="Refresh every registered devbox.")
 @click.option(
-    "--with-brew",
-    is_flag=True,
-    default=False,
-    help=(
-        "Also reinstall brew packages: BOTH the loadout Brewfile AND the "
-        "preset's brew_extras (two different sets). Required to pick up preset "
-        "brew_extras changes. Slow: 15-30 min/box, serial under --all."
-    ),
-)
-@click.option(
     "--with-globals",
     is_flag=True,
     default=False,
-    help=(
-        "Also reinstall npm/pip globals: BOTH the loadout globals AND the "
-        "preset's npm_globals/pip_globals. Required to pick up preset globals changes."
-    ),
+    help="Also reinstall the preset's npm_globals / pip_globals.",
 )
-def refresh(name: str | None, all_: bool, with_brew: bool, with_globals: bool) -> None:
-    """Push current dotfiles/config to an existing devbox without destroying state."""
+def refresh(name: str | None, all_: bool, with_globals: bool) -> None:
+    """Push current dotfiles/config to an existing devbox without destroying state.
+
+    Always refreshes dotfiles and reinstalls the preset's brew_extras. The
+    full loadout Brewfile is never re-run — rebuild the devbox instead.
+    """
     if all_ and name:
         console.print("[red]✗[/red] Pass either NAME or --all, not both")
         sys.exit(1)
@@ -131,9 +122,7 @@ def refresh(name: str | None, all_: bool, with_brew: bool, with_globals: bool) -
         # name is non-None — guarded by the "Pass a devbox NAME or --all" check above.
         targets = [name] if name is not None else []
 
-    scope_parts = ["dotfiles"]
-    if with_brew:
-        scope_parts.append("brew")
+    scope_parts = ["dotfiles", "brew extras"]
     if with_globals:
         scope_parts.append("globals")
     scope = ", ".join(scope_parts)
@@ -142,7 +131,7 @@ def refresh(name: str | None, all_: bool, with_brew: bool, with_globals: bool) -
     for box in targets:
         try:
             with console.status(f"[bold]Refreshing {box!r} ({scope})..."):
-                refresh_devbox(box, with_brew=with_brew, with_globals=with_globals)
+                refresh_devbox(box, with_globals=with_globals)
             console.print(f"[green]✓[/green] {box} refreshed ({scope})")
         except (DevboxError, ValueError) as exc:
             # Catch DevboxError (incl. BootstrapError subclass) and ValueError

--- a/src/devbox/core.py
+++ b/src/devbox/core.py
@@ -465,18 +465,18 @@ def rebuild_devbox(
 def refresh_devbox(
     name: str,
     *,
-    with_brew: bool = False,
     with_globals: bool = False,
     registry_path: Path | None = None,
     presets_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Push current dotfiles/config to an existing devbox without destroying state.
 
-    Always runs ``loadout update`` over SSH. ``with_brew`` additionally
-    drops ``--skip-brew`` from the loadout invocation (running the loadout
-    Brewfile) AND re-runs the preset's ``brew_extras`` — these are different
-    sets, both expensive at the non-standard ``~/.homebrew`` prefix.
-    ``with_globals`` is analogous for ``npm_globals`` / ``pip_globals``.
+    Runs ``loadout update --skip-brew --skip-globals`` over SSH, then
+    installs the preset's ``brew_extras`` as the devbox user. The loadout
+    Brewfile is never re-run here — it's a 30+ minute compile at the
+    non-standard ``~/.homebrew`` prefix, so if it needs to change, rebuild
+    the devbox instead. ``with_globals`` additionally reinstalls the
+    preset's ``npm_globals`` and ``pip_globals``.
 
     Refuses to refresh devboxes that are not in ``READY`` state (e.g.
     ``CREATING`` / ``NUKING``) to avoid racing in-flight bootstrap.
@@ -508,26 +508,20 @@ def refresh_devbox(
         refresh_dotfiles,
     )
 
-    if (with_brew or with_globals) and not preset_obj.loadout_orgs:
+    if not preset_obj.loadout_orgs and (preset_obj.brew_extras or with_globals):
         logger.warning(
             "Preset %r has no loadout_orgs; loadout update is a no-op, "
             "but preset brew_extras/globals will still be installed",
             entry.preset,
         )
 
-    refresh_dotfiles(
-        home_dir,
-        preset_obj,
-        username,
-        with_brew=with_brew,
-        with_globals=with_globals,
-    )
+    refresh_dotfiles(home_dir, preset_obj, username)
 
     # Run install steps via SSH as the devbox user — avoids host sudo so
     # refresh works in non-interactive shells.
     ssh_base = build_ssh_base(preset_obj, username)
 
-    if with_brew and preset_obj.brew_extras:
+    if preset_obj.brew_extras:
         install_brew_extras(home_dir, preset_obj.brew_extras, username, ssh_base=ssh_base)
 
     if with_globals:

--- a/src/devbox/core.py
+++ b/src/devbox/core.py
@@ -506,6 +506,7 @@ def refresh_devbox(
         install_npm_globals,
         install_pip_globals,
         refresh_dotfiles,
+        refresh_shell_env,
     )
 
     if not preset_obj.loadout_orgs and (preset_obj.brew_extras or with_globals):
@@ -514,6 +515,10 @@ def refresh_devbox(
             "but preset brew_extras/globals will still be installed",
             entry.preset,
         )
+
+    # Push shell env files first so PATH is correct before loadout update
+    # runs any hooks that shell out to brew-installed tools.
+    refresh_shell_env(home_dir, preset_obj, username)
 
     refresh_dotfiles(home_dir, preset_obj, username)
 

--- a/src/devbox/core.py
+++ b/src/devbox/core.py
@@ -501,6 +501,7 @@ def refresh_devbox(
     home_dir = Path(f"/Users/{username}")
 
     from devbox.bootstrap import (
+        _ssh_base,
         install_brew_extras,
         install_npm_globals,
         install_pip_globals,
@@ -522,14 +523,18 @@ def refresh_devbox(
         with_globals=with_globals,
     )
 
+    # Run install steps via SSH as the devbox user — avoids host sudo so
+    # refresh works in non-interactive shells.
+    ssh_base = _ssh_base(preset_obj, username)
+
     if with_brew and preset_obj.brew_extras:
-        install_brew_extras(home_dir, preset_obj.brew_extras, username)
+        install_brew_extras(home_dir, preset_obj.brew_extras, username, ssh_base=ssh_base)
 
     if with_globals:
         if preset_obj.npm_globals:
-            install_npm_globals(home_dir, preset_obj.npm_globals, username)
+            install_npm_globals(home_dir, preset_obj.npm_globals, username, ssh_base=ssh_base)
         if preset_obj.pip_globals:
-            install_pip_globals(home_dir, preset_obj.pip_globals, username)
+            install_pip_globals(home_dir, preset_obj.pip_globals, username, ssh_base=ssh_base)
 
     return entry.model_dump()
 

--- a/src/devbox/core.py
+++ b/src/devbox/core.py
@@ -501,7 +501,7 @@ def refresh_devbox(
     home_dir = Path(f"/Users/{username}")
 
     from devbox.bootstrap import (
-        _ssh_base,
+        build_ssh_base,
         install_brew_extras,
         install_npm_globals,
         install_pip_globals,
@@ -525,7 +525,7 @@ def refresh_devbox(
 
     # Run install steps via SSH as the devbox user — avoids host sudo so
     # refresh works in non-interactive shells.
-    ssh_base = _ssh_base(preset_obj, username)
+    ssh_base = build_ssh_base(preset_obj, username)
 
     if with_brew and preset_obj.brew_extras:
         install_brew_extras(home_dir, preset_obj.brew_extras, username, ssh_base=ssh_base)

--- a/src/devbox/zshrc.py
+++ b/src/devbox/zshrc.py
@@ -18,6 +18,37 @@ HEARTBEAT_HOOK = (
 
 ENV_SOURCE_LINE = "# devbox environment\n[ -f ~/.devbox-env ] && source ~/.devbox-env"
 
+ZSHENV_CONTENT = (
+    "# devbox: per-devbox Homebrew environment\n"
+    'export HOMEBREW_PREFIX="$HOME/.homebrew"\n'
+    'export HOMEBREW_CELLAR="$HOME/.homebrew/Cellar"\n'
+    'export HOMEBREW_REPOSITORY="$HOME/.homebrew"\n'
+    'export PATH="$HOME/.homebrew/bin:$HOME/.homebrew/sbin:$PATH"\n'
+    'export MANPATH="$HOME/.homebrew/share/man${MANPATH+:$MANPATH}:"\n'
+    'export INFOPATH="$HOME/.homebrew/share/info:${INFOPATH:-}"\n'
+    'fpath=("$HOME/.homebrew/share/zsh/site-functions" $^fpath(-/N))\n'
+    "\n"
+    "# devbox: SSH agent — ensure the key is loaded for git/ssh operations\n"
+    'if [[ -z "$SSH_AUTH_SOCK" ]]; then\n'
+    '    eval "$(ssh-agent -s)" >/dev/null 2>&1\n'
+    "fi\n"
+    "ssh-add -q $(awk '/IdentityFile/{print $2}' ~/.ssh/config"
+    ' | sed "s|^~|$HOME|") 2>/dev/null\n'
+)
+
+# .zprofile runs after /etc/zprofile (which calls path_helper) for login
+# shells. path_helper reads /etc/paths.d/homebrew from the parent user's
+# Homebrew install and prepends /opt/homebrew/bin ahead of our PATH,
+# shadowing the per-devbox ~/.homebrew binaries. Re-prepend here to put
+# ~/.homebrew first again so the devbox's own tools win.
+ZPROFILE_CONTENT = (
+    "# devbox: re-prepend ~/.homebrew/bin after macOS path_helper runs\n"
+    "# (parent /opt/homebrew would otherwise shadow our per-devbox brew).\n"
+    'if [ -x "$HOME/.homebrew/bin/brew" ]; then\n'
+    '    eval "$($HOME/.homebrew/bin/brew shellenv)"\n'
+    "fi\n"
+)
+
 LOGIN_NOTICE = ""
 
 LOADOUT_NOTICE = LOGIN_NOTICE  # backward-compat alias
@@ -48,26 +79,14 @@ def write_zshrc(home_dir: Path, name: str, username: str) -> None:
     .zshrc.local adds devbox-specific hooks that survive loadout builds.
     """
     zshenv_path = home_dir / ".zshenv"
-    zshenv_path.write_text(
-        "# devbox: per-devbox Homebrew environment\n"
-        'export HOMEBREW_PREFIX="$HOME/.homebrew"\n'
-        'export HOMEBREW_CELLAR="$HOME/.homebrew/Cellar"\n'
-        'export HOMEBREW_REPOSITORY="$HOME/.homebrew"\n'
-        'export PATH="$HOME/.homebrew/bin:$HOME/.homebrew/sbin:$PATH"\n'
-        'export MANPATH="$HOME/.homebrew/share/man${MANPATH+:$MANPATH}:"\n'
-        'export INFOPATH="$HOME/.homebrew/share/info:${INFOPATH:-}"\n'
-        'fpath=("$HOME/.homebrew/share/zsh/site-functions" $^fpath(-/N))\n'
-        "\n"
-        "# devbox: SSH agent — ensure the key is loaded for git/ssh operations\n"
-        'if [[ -z "$SSH_AUTH_SOCK" ]]; then\n'
-        '    eval "$(ssh-agent -s)" >/dev/null 2>&1\n'
-        "fi\n"
-        "ssh-add -q $(awk '/IdentityFile/{print $2}' ~/.ssh/config"
-        ' | sed "s|^~|$HOME|") 2>/dev/null\n',
-        encoding="utf-8",
-    )
+    zshenv_path.write_text(ZSHENV_CONTENT, encoding="utf-8")
     os.chmod(zshenv_path, 0o644)
     chown_path(zshenv_path, username)
+
+    zprofile_path = home_dir / ".zprofile"
+    zprofile_path.write_text(ZPROFILE_CONTENT, encoding="utf-8")
+    os.chmod(zprofile_path, 0o644)
+    chown_path(zprofile_path, username)
 
     zshrc_path = home_dir / ".zshrc.local"
     zshrc_path.write_text(generate_zshrc_local(name), encoding="utf-8")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -214,6 +214,17 @@ class TestInstallBrewExtras:
         with pytest.raises(BootstrapError, match="brew extras"):
             install_brew_extras(HOME, ["bad-pkg"], USERNAME)
 
+    def test_ssh_base_runs_over_ssh(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+        ssh_base = ["ssh", "-i", "/k", f"{USERNAME}@localhost"]
+        install_brew_extras(HOME, ["jq"], USERNAME, ssh_base=ssh_base)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ssh_base
+        assert "sudo" not in cmd
+        # inner must be wrapped as bash -c '<quoted>' for shell parity
+        assert cmd[4].startswith("bash -c ")
+        assert "jq" in cmd[4]
+
 
 # ---------------------------------------------------------------------------
 # install_npm_globals
@@ -238,6 +249,15 @@ class TestInstallNpmGlobals:
         with pytest.raises(BootstrapError, match="npm globals"):
             install_npm_globals(HOME, ["bad"], USERNAME)
 
+    def test_ssh_base_runs_over_ssh(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+        ssh_base = ["ssh", "-i", "/k", f"{USERNAME}@localhost"]
+        install_npm_globals(HOME, ["typescript"], USERNAME, ssh_base=ssh_base)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ssh_base
+        assert "sudo" not in cmd
+        assert cmd[4].startswith("bash -c ")
+
 
 # ---------------------------------------------------------------------------
 # install_pip_globals
@@ -261,6 +281,15 @@ class TestInstallPipGlobals:
         mocker.patch("devbox.bootstrap.subprocess.run", return_value=_fail())
         with pytest.raises(BootstrapError, match="pip globals"):
             install_pip_globals(HOME, ["bad"], USERNAME)
+
+    def test_ssh_base_runs_over_ssh(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+        ssh_base = ["ssh", "-i", "/k", f"{USERNAME}@localhost"]
+        install_pip_globals(HOME, ["ruff"], USERNAME, ssh_base=ssh_base)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ssh_base
+        assert "sudo" not in cmd
+        assert cmd[4].startswith("bash -c ")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -325,8 +325,8 @@ class TestRefreshCommand:
     def test_passes_flags(self, runner: CliRunner, mocker: MockerFixture) -> None:
         mock_refresh = mocker.patch("devbox.cli.refresh_devbox")
         mocker.patch("devbox.cli.console")
-        runner.invoke(cli, ["refresh", "mybox", "--with-brew", "--with-globals"])
-        mock_refresh.assert_called_once_with("mybox", with_brew=True, with_globals=True)
+        runner.invoke(cli, ["refresh", "mybox", "--with-globals"])
+        mock_refresh.assert_called_once_with("mybox", with_globals=True)
 
     def test_requires_name_or_all(self, runner: CliRunner, mocker: MockerFixture) -> None:
         mocker.patch("devbox.cli.console")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -779,9 +779,14 @@ class TestRefreshDevbox:
         )
 
         mock_brew.assert_called_once()
-        args = mock_brew.call_args[0]
+        args, kwargs = mock_brew.call_args
         assert args[1] == ["jq", "fd"]
         assert args[2] == "dx-mybox"
+        # ssh_base must be threaded through so installs run over SSH,
+        # not via host sudo (the whole point of the refactor).
+        assert "ssh_base" in kwargs
+        assert kwargs["ssh_base"][0] == "ssh"
+        assert kwargs["ssh_base"][-1] == "dx-mybox@localhost"
 
     def test_with_globals_runs_npm_and_pip(self, tmp_path: Path, mocker: MockerFixture) -> None:
         registry_path, presets_dir = self._setup(
@@ -800,6 +805,10 @@ class TestRefreshDevbox:
 
         mock_npm.assert_called_once()
         mock_pip.assert_called_once()
+        for mock_call in (mock_npm.call_args, mock_pip.call_args):
+            _, kwargs = mock_call
+            assert "ssh_base" in kwargs
+            assert kwargs["ssh_base"][0] == "ssh"
 
     def test_not_found_raises(self, tmp_path: Path) -> None:
         registry_path = tmp_path / "registry.json"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -735,6 +735,10 @@ class TestRebuildDevbox:
 
 
 class TestRefreshDevbox:
+    @pytest.fixture(autouse=True)
+    def _mock_shell_env(self, mocker: MockerFixture) -> Any:
+        return mocker.patch("devbox.bootstrap.refresh_shell_env")
+
     def _setup(self, tmp_path: Path, **preset_overrides: Any) -> tuple[Path, Path]:
         presets_dir = tmp_path / "presets"
         presets_dir.mkdir()
@@ -771,6 +775,15 @@ class TestRefreshDevbox:
         # Globals are opt-in via --with-globals.
         mock_npm.assert_not_called()
         mock_pip.assert_not_called()
+
+    def test_pushes_shell_env(
+        self, tmp_path: Path, mocker: MockerFixture, _mock_shell_env: Any
+    ) -> None:
+        registry_path, presets_dir = self._setup(tmp_path)
+        mocker.patch("devbox.bootstrap.refresh_dotfiles")
+        refresh_devbox("mybox", registry_path=registry_path, presets_dir=presets_dir)
+        # .zprofile fix for path_helper shadowing must land on every refresh.
+        _mock_shell_env.assert_called_once()
 
     def test_with_globals_runs_npm_and_pip(self, tmp_path: Path, mocker: MockerFixture) -> None:
         registry_path, presets_dir = self._setup(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -746,11 +746,11 @@ class TestRefreshDevbox:
         )
         return registry_path, presets_dir
 
-    def test_default_calls_refresh_dotfiles_only(
+    def test_default_installs_brew_extras_and_refreshes_dotfiles(
         self, tmp_path: Path, mocker: MockerFixture
     ) -> None:
         registry_path, presets_dir = self._setup(
-            tmp_path, brew_extras=["jq"], npm_globals=["typescript"]
+            tmp_path, brew_extras=["jq", "fd"], npm_globals=["typescript"]
         )
         mock_refresh = mocker.patch("devbox.bootstrap.refresh_dotfiles")
         mock_brew = mocker.patch("devbox.bootstrap.install_brew_extras")
@@ -760,33 +760,17 @@ class TestRefreshDevbox:
         refresh_devbox("mybox", registry_path=registry_path, presets_dir=presets_dir)
 
         mock_refresh.assert_called_once()
-        _, kwargs = mock_refresh.call_args
-        assert kwargs == {"with_brew": False, "with_globals": False}
-        mock_brew.assert_not_called()
-        mock_npm.assert_not_called()
-        mock_pip.assert_not_called()
-
-    def test_with_brew_runs_extras(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        registry_path, presets_dir = self._setup(tmp_path, brew_extras=["jq", "fd"])
-        mocker.patch("devbox.bootstrap.refresh_dotfiles")
-        mock_brew = mocker.patch("devbox.bootstrap.install_brew_extras")
-
-        refresh_devbox(
-            "mybox",
-            with_brew=True,
-            registry_path=registry_path,
-            presets_dir=presets_dir,
-        )
-
         mock_brew.assert_called_once()
         args, kwargs = mock_brew.call_args
         assert args[1] == ["jq", "fd"]
         assert args[2] == "dx-mybox"
-        # ssh_base must be threaded through so installs run over SSH,
-        # not via host sudo (the whole point of the refactor).
+        # ssh_base threaded through so installs run over SSH (no host sudo).
         assert "ssh_base" in kwargs
         assert kwargs["ssh_base"][0] == "ssh"
         assert kwargs["ssh_base"][-1] == "dx-mybox@localhost"
+        # Globals are opt-in via --with-globals.
+        mock_npm.assert_not_called()
+        mock_pip.assert_not_called()
 
     def test_with_globals_runs_npm_and_pip(self, tmp_path: Path, mocker: MockerFixture) -> None:
         registry_path, presets_dir = self._setup(
@@ -835,18 +819,11 @@ class TestRefreshDevbox:
         with pytest.raises(DevboxError, match="not ready"):
             refresh_devbox("mybox", registry_path=registry_path, presets_dir=presets_dir)
 
-    def test_with_brew_skips_install_when_no_extras(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
+    def test_skips_brew_install_when_no_extras(self, tmp_path: Path, mocker: MockerFixture) -> None:
         registry_path, presets_dir = self._setup(tmp_path, brew_extras=[])
         mocker.patch("devbox.bootstrap.refresh_dotfiles")
         mock_brew = mocker.patch("devbox.bootstrap.install_brew_extras")
-        refresh_devbox(
-            "mybox",
-            with_brew=True,
-            registry_path=registry_path,
-            presets_dir=presets_dir,
-        )
+        refresh_devbox("mybox", registry_path=registry_path, presets_dir=presets_dir)
         mock_brew.assert_not_called()
 
     def test_refresh_dotfiles_failure_short_circuits(
@@ -861,7 +838,6 @@ class TestRefreshDevbox:
         with pytest.raises(DevboxError, match="ssh exploded"):
             refresh_devbox(
                 "mybox",
-                with_brew=True,
                 registry_path=registry_path,
                 presets_dir=presets_dir,
             )

--- a/tests/test_zshrc.py
+++ b/tests/test_zshrc.py
@@ -124,6 +124,19 @@ class TestWriteZshrc:
         mode = os.stat(tmp_path / ".zshenv").st_mode & 0o777
         assert mode == 0o644
 
+    def test_creates_zprofile_with_brew_shellenv(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("devbox.zshrc.chown_path")
+        write_zshrc(tmp_path, "my-dev", "dx-my-dev")
+        zprofile = (tmp_path / ".zprofile").read_text(encoding="utf-8")
+        # Must eval brew shellenv to re-prepend ~/.homebrew after path_helper
+        # runs in /etc/zprofile — otherwise parent's /opt/homebrew shadows it.
+        assert "brew shellenv" in zprofile
+        assert "$HOME/.homebrew/bin/brew" in zprofile
+        mode = os.stat(tmp_path / ".zprofile").st_mode & 0o777
+        assert mode == 0o644
+
     def test_chown_called_with_correct_args(self, tmp_path: Path, mocker: MockerFixture) -> None:
         mock_chown = mocker.patch("devbox.zshrc.chown_path")
         write_zshrc(tmp_path, "my-dev", "dx-my-dev")


### PR DESCRIPTION
## Summary
- `install_brew_extras`, `install_npm_globals`, `install_pip_globals` accept optional `ssh_base` kwarg; when set, commands run over SSH as the devbox user instead of `sudo -u` locally.
- `refresh_devbox` threads `ssh_base` so `--with-brew` / `--with-globals` work in non-interactive shells — no host sudo password prompt.
- Create flow unchanged: `bootstrap_user` still uses `sudo -u` (SSH isn't up yet during bootstrap).

Fixes #51.

## Test plan
- [x] ruff check / format
- [x] mypy
- [x] pytest (587 passed)
- [ ] `devbox refresh cardonomics --with-brew` against a real devbox