### PR TITLE
feat: multi-profile AWS config in devbox presets (#54)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -177,8 +177,7 @@ Presets live in `~/.dotfiles-private/devbox/presets/<name>.json`:
   "version": 1,
   "name": "acme-data",
   "description": "dbt + Snowflake + Python data work",
-  "provider": "anthropic-work",
-  "aws_profile": "acme-main",
+  "provider": "aws",
   "github_account": "acme-dev",
   "node_version": "lts",
   "python_version": "3.12",
@@ -190,11 +189,25 @@ Presets live in `~/.dotfiles-private/devbox/presets/<name>.json`:
   "env_vars": {
     "SNOWFLAKE_ACCOUNT": "op://Work/Snowflake/account",
     "DBT_PROFILES_DIR": "~/.dbt"
+  },
+  "aws": {
+    "default_profile": "acme-main",
+    "profiles": [
+      {
+        "name": "acme-main",
+        "type": "static",
+        "region": "us-east-1",
+        "access_key_id": "op://Work/acme-aws/access_key_id",
+        "secret_access_key": "op://Work/acme-aws/secret_access_key"
+      }
+    ]
   }
 }
 ```
 
 `env_vars` values may use `op://` references — these are resolved at `devbox create` time via `op read`, and the resolved values are written to `/Users/dx-<name>/.devbox-env` (mode `0600`). The devbox user's `.zshrc` sources this file on login. Plaintext secrets are never stored in the preset or registry.
+
+The optional `aws:` block configures one or more AWS CLI profiles inside the devbox. Static profiles resolve `op://` references on the host at create/refresh time and write `~/.aws/credentials` (mode `0600`); SSO profiles write config-only blocks into `~/.aws/config` and require an interactive `aws sso login --profile <name>` per session. `AWS_PROFILE` is set to `default_profile` in `.devbox-env`.
 
 Since the devbox is disposable and 1Password is the source of truth, secret rotation is handled by nuking the devbox and recreating it.
 

--- a/src/devbox/auth.py
+++ b/src/devbox/auth.py
@@ -9,10 +9,11 @@ import logging
 import os
 import re
 from pathlib import Path
+from typing import NamedTuple
 
 from devbox.exceptions import AuthError
 from devbox.onepassword import get_secret
-from devbox.presets import Preset
+from devbox.presets import AwsSsoProfile, AwsStaticProfile, Preset
 from devbox.ssh import chown_path
 from devbox.utils import shell_escape
 
@@ -20,18 +21,23 @@ logger = logging.getLogger(__name__)
 
 _ENV_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
-_AWS_REGION_RE = re.compile(r"^[a-z]{2}-[a-z]+-\d+$")
 _AWS_ACCESS_KEY_RE = re.compile(r"^[A-Z0-9]{16,128}$")
 _AWS_SECRET_KEY_RE = re.compile(r"^[A-Za-z0-9/+=]{16,128}$")
 
 
-def _validate_aws_values(region: str, access_key: str, secret_key: str) -> None:
-    """Validate AWS credential values against expected patterns.
+class AwsRender(NamedTuple):
+    """Rendered contents for the two AWS config files plus SSO profile names."""
 
-    Raises :exc:`AuthError` if any value is malformed.
+    config: str
+    credentials: str
+    sso_profiles: list[str]
+
+
+def _validate_aws_keys(access_key: str, secret_key: str) -> None:
+    """Validate AWS key values against expected patterns.
+
+    Raises :exc:`AuthError` if either value is malformed.
     """
-    if not _AWS_REGION_RE.match(region):
-        raise AuthError(f"Invalid AWS region format: {region!r}")
     if not _AWS_ACCESS_KEY_RE.match(access_key):
         raise AuthError("Invalid AWS access key format")
     if not _AWS_SECRET_KEY_RE.match(secret_key):
@@ -52,79 +58,124 @@ def _write_env_export(env_path: Path, key: str, value: str) -> None:
         fh.write(line)
 
 
-def inject_aws_auth(home_dir: Path, preset: Preset, username: str) -> None:
-    """Resolve AWS credentials from 1Password and write ~/.aws config files.
+def _write_file_0600(path: Path, content: str) -> None:
+    # O_NOFOLLOW rejects symlinks so a prior attacker can't redirect the write.
+    fd = os.open(
+        str(path),
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+        0o600,
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(content)
 
-    Uses ``preset.aws_profile`` to construct the 1Password references.
-    Creates ``~/.aws/config`` and ``~/.aws/credentials`` with proper
-    permissions (0700 dir, 0600 files), chowned to the devbox user.
 
-    Only applies when ``preset.provider == "aws"``.
+def log_sso_hints(sso_profiles: list[str]) -> None:
+    """Log ``aws sso login`` reminders for each SSO profile."""
+    for profile_name in sso_profiles:
+        logger.info(
+            "SSO profile %r requires interactive login: aws sso login --profile %s",
+            profile_name,
+            profile_name,
+        )
+
+
+def render_aws_files(preset: Preset) -> AwsRender:
+    """Build the contents of ``~/.aws/config`` and ``~/.aws/credentials``.
+
+    Resolves ``op://`` references for static profiles via 1Password. Returns
+    an :class:`AwsRender` tuple; both text fields are empty strings when
+    ``preset.aws`` is unset or the corresponding section has no profiles.
+
+    Raises :exc:`AuthError` on resolution or validation failure.
+    """
+    if preset.aws is None:
+        return AwsRender("", "", [])
+
+    config_parts: list[str] = []
+    creds_parts: list[str] = []
+    sso_profiles: list[str] = []
+
+    for profile in preset.aws.profiles:
+        if isinstance(profile, AwsStaticProfile):
+            try:
+                access_key = get_secret(profile.access_key_id)
+                secret_key = get_secret(profile.secret_access_key)
+            except Exception as exc:
+                raise AuthError(
+                    f"Failed to resolve AWS credentials for profile {profile.name!r}: {exc}"
+                ) from exc
+
+            _validate_aws_keys(access_key, secret_key)
+
+            config_parts.append(
+                f"[profile {profile.name}]\n"
+                f"region = {profile.region}\n"
+                f"output = {profile.output}\n"
+            )
+            creds_parts.append(
+                f"[{profile.name}]\n"
+                f"aws_access_key_id = {access_key}\n"
+                f"aws_secret_access_key = {secret_key}\n"
+            )
+        elif isinstance(profile, AwsSsoProfile):
+            config_parts.append(
+                f"[profile {profile.name}]\n"
+                f"sso_start_url = {profile.sso_start_url}\n"
+                f"sso_region = {profile.sso_region}\n"
+                f"sso_account_id = {profile.sso_account_id}\n"
+                f"sso_role_name = {profile.sso_role_name}\n"
+                f"region = {profile.region}\n"
+                f"output = {profile.output}\n"
+            )
+            sso_profiles.append(profile.name)
+
+    return AwsRender("\n".join(config_parts), "\n".join(creds_parts), sso_profiles)
+
+
+def inject_aws_auth(home_dir: Path, preset: Preset, username: str) -> list[str]:
+    """Write ``~/.aws/config`` and ``~/.aws/credentials`` from the preset's aws block.
+
+    Overwrites both files wholesale. Skips the credentials file if no static
+    profiles are present. Creates ``~/.aws`` with 0700 perms and files with
+    0600, chowned to the devbox user.
+
+    No-op if ``preset.aws`` is not set. Returns the list of SSO profile names
+    (for which the caller should print an ``aws sso login`` hint).
+
     Raises :exc:`AuthError` on failure.
     """
-    if preset.provider != "aws":
-        msg = f"inject_aws_auth requires provider 'aws', got {preset.provider!r}"
-        raise AuthError(msg)
+    if preset.aws is None:
+        return []
 
-    if not preset.aws_profile:
-        raise AuthError("preset.aws_profile is required for AWS auth injection")
-
-    profile = preset.aws_profile
-
-    try:
-        access_key = get_secret(f"op://Development/{profile}/access-key-id")
-        secret_key = get_secret(f"op://Development/{profile}/secret-access-key")
-        region = get_secret(f"op://Development/{profile}/region")
-    except Exception as exc:
-        raise AuthError(f"Failed to resolve AWS credentials: {exc}") from exc
-
-    _validate_aws_values(region, access_key, secret_key)
+    rendered = render_aws_files(preset)
 
     aws_dir = home_dir / ".aws"
-
     try:
         aws_dir.mkdir(mode=0o700, exist_ok=True)
-
-        config_path = aws_dir / "config"
-        config_content = f"[profile default]\nregion = {region}\noutput = json\n"
-        fd = os.open(
-            str(config_path),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o600,
-        )
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(config_content)
-
-        credentials_path = aws_dir / "credentials"
-        credentials_content = (
-            f"[default]\naws_access_key_id = {access_key}\naws_secret_access_key = {secret_key}\n"
-        )
-        fd = os.open(
-            str(credentials_path),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o600,
-        )
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(credentials_content)
-
+        # Re-apply perms in case the dir pre-existed with looser bits.
+        os.chmod(aws_dir, 0o700)
+        _write_file_0600(aws_dir / "config", rendered.config)
+        if rendered.credentials:
+            _write_file_0600(aws_dir / "credentials", rendered.credentials)
         chown_path(aws_dir, username)
     except AuthError:
         raise
     except Exception as exc:
         raise AuthError(f"Failed to write AWS credentials: {exc}") from exc
 
+    return rendered.sso_profiles
 
-def inject_auth(home_dir: Path, preset: Preset, username: str) -> None:
-    """Dispatch auth injection based on preset provider.
 
-    - ``"local"``: no-op (user runs ``claude /login`` after first SSH)
-    - ``"aws"``: injects AWS credentials
+def inject_auth(home_dir: Path, preset: Preset, username: str) -> list[str]:
+    """Dispatch auth injection based on the preset's provider and aws block.
 
-    Raises :exc:`AuthError` on failure.
+    AWS profile injection is orthogonal to ``provider``: any preset with an
+    ``aws:`` block gets ``~/.aws`` written, regardless of whether the devbox
+    itself runs locally or on EC2. Returns the list of SSO profile names
+    present (empty when no interactive login is required).
+
+    Raises :exc:`AuthError` on unknown provider or injection failure.
     """
-    if preset.provider == "local":
-        return  # Claude Code auth handled via `claude /login` over SSH
-    elif preset.provider == "aws":
-        inject_aws_auth(home_dir, preset, username)
-    else:
+    if preset.provider not in ("local", "aws"):
         raise AuthError(f"Unknown provider: {preset.provider!r}")
+    return inject_aws_auth(home_dir, preset, username)

--- a/src/devbox/bootstrap.py
+++ b/src/devbox/bootstrap.py
@@ -13,8 +13,11 @@ import time
 from collections.abc import Callable
 from pathlib import Path
 
-from devbox.exceptions import BootstrapError
+from devbox import onepassword
+from devbox.auth import render_aws_files
+from devbox.exceptions import AuthError, BootstrapError, OnePasswordError
 from devbox.presets import Preset
+from devbox.utils import shell_escape
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +132,96 @@ def refresh_shell_env(home_dir: Path, preset: Preset, username: str) -> None:
             error_prefix=f"write ~{filename}",
             timeout=10,
         )
+
+
+def refresh_aws_config(home_dir: Path, preset: Preset, username: str) -> list[str]:
+    """Overwrite ``~/.aws/config`` and ``~/.aws/credentials`` on an existing devbox.
+
+    Resolves ``op://`` references on the host and pushes the rendered files
+    over SSH, then applies 0700/0600 perms. No-op if ``preset.aws`` is unset.
+
+    Returns the list of SSO profile names present (for post-refresh hint).
+    Raises :exc:`BootstrapError` on SSH failure.
+    """
+    _validate_username(username)
+    if preset.aws is None:
+        return []
+
+    try:
+        rendered = render_aws_files(preset)
+    except AuthError as exc:
+        raise BootstrapError(f"refresh AWS config: {exc}") from exc
+
+    ssh_base = build_ssh_base(preset, username)
+
+    _run_checked(
+        [*ssh_base, "mkdir -p ~/.aws && chmod 0700 ~/.aws"],
+        error_prefix="create ~/.aws",
+        timeout=10,
+    )
+
+    files: list[tuple[str, str]] = [("/.aws/config", rendered.config)]
+    if rendered.credentials:
+        files.append(("/.aws/credentials", rendered.credentials))
+
+    for filename, content in files:
+        # Heredoc delimiter is single-quoted so the remote shell does not
+        # expand $/backticks. All input fields are regex-bounded with no
+        # newlines, so the delimiter can't appear inside content.
+        _run_checked(
+            [
+                *ssh_base,
+                f"cat > ~{filename} << 'DEVBOX_AWS_EOF'\n"
+                f"{content}DEVBOX_AWS_EOF\n"
+                f"chmod 0600 ~{filename}",
+            ],
+            error_prefix=f"write ~{filename}",
+            timeout=10,
+        )
+
+    return rendered.sso_profiles
+
+
+def refresh_devbox_env(home_dir: Path, preset: Preset, username: str) -> None:
+    """Push ``~/.devbox-env`` to an existing devbox over SSH.
+
+    Re-resolves ``op://`` refs in ``preset.env_vars`` on the host and
+    includes ``AWS_PROFILE`` when ``preset.aws`` is set. Overwrites the
+    file wholesale — preset is the source of truth.
+
+    Content is base64-encoded over the wire so arbitrary 1Password secret
+    values (which may contain newlines or shell metacharacters) can't break
+    out of the remote write.
+
+    Raises :exc:`BootstrapError` on failure.
+    """
+    import base64
+
+    _validate_username(username)
+
+    resolved: dict[str, str] = {}
+    if preset.env_vars:
+        try:
+            resolved = onepassword.resolve_env_vars(preset.env_vars)
+        except OnePasswordError as exc:
+            raise BootstrapError(f"refresh env: {exc}") from exc
+    if preset.aws is not None:
+        resolved["AWS_PROFILE"] = preset.aws.default_profile
+
+    if not resolved:
+        return
+
+    lines = "\n".join(f"export {k}={shell_escape(v)}" for k, v in resolved.items()) + "\n"
+    payload = base64.b64encode(lines.encode("utf-8")).decode("ascii")
+    ssh_base = build_ssh_base(preset, username)
+    _run_checked(
+        [
+            *ssh_base,
+            f"echo {payload} | base64 -d > ~/.devbox-env && chmod 0600 ~/.devbox-env",
+        ],
+        error_prefix="write ~/.devbox-env",
+        timeout=10,
+    )
 
 
 def refresh_dotfiles(

--- a/src/devbox/core.py
+++ b/src/devbox/core.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from devbox import iterm2, macos, onepassword, ssh, sshd, sudoers
-from devbox.auth import inject_auth
+from devbox.auth import inject_auth, log_sso_hints
 from devbox.bootstrap import bootstrap_user
 from devbox.exceptions import DevboxError
 from devbox.health import format_last_seen, get_health, read_heartbeat
@@ -213,15 +213,21 @@ def create_devbox(
             ssh.populate_authorized_keys(home_dir, target_user=username)
 
             step("Resolving environment variables")
-            if preset_obj.env_vars:
-                resolved = onepassword.resolve_env_vars(preset_obj.env_vars)
+            resolved = (
+                onepassword.resolve_env_vars(preset_obj.env_vars) if preset_obj.env_vars else {}
+            )
+            if preset_obj.aws is not None:
+                resolved["AWS_PROFILE"] = preset_obj.aws.default_profile
+            if resolved:
                 write_env_file(home_dir, resolved, target_user=username)
 
             step("Injecting auth credentials")
+            sso_profiles: list[str] = []
             try:
-                inject_auth(home_dir, preset_obj, username)
+                sso_profiles = inject_auth(home_dir, preset_obj, username)
             except DevboxError as exc:
                 logger.warning("Auth injection failed (non-fatal): %s", exc)
+            log_sso_hints(sso_profiles)
 
             step("Writing .zshrc")
             try:
@@ -505,6 +511,8 @@ def refresh_devbox(
         install_brew_extras,
         install_npm_globals,
         install_pip_globals,
+        refresh_aws_config,
+        refresh_devbox_env,
         refresh_dotfiles,
         refresh_shell_env,
     )
@@ -519,7 +527,8 @@ def refresh_devbox(
     # Push shell env files first so PATH is correct before loadout update
     # runs any hooks that shell out to brew-installed tools.
     refresh_shell_env(home_dir, preset_obj, username)
-
+    refresh_devbox_env(home_dir, preset_obj, username)
+    log_sso_hints(refresh_aws_config(home_dir, preset_obj, username))
     refresh_dotfiles(home_dir, preset_obj, username)
 
     # Run install steps via SSH as the devbox user — avoids host sudo so

--- a/src/devbox/presets.py
+++ b/src/devbox/presets.py
@@ -8,9 +8,17 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from devbox.exceptions import PresetError
 from devbox.naming import GITHUB_ACCOUNT_RE, validate_name
@@ -25,6 +33,56 @@ _SAFE_VALUE_RE = re.compile(r"^[a-zA-Z0-9@_./:=~-]*$")
 _ENV_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _REPO_RE = re.compile(r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$")
 _VALID_PROVIDERS = frozenset({"local", "aws"})
+_AwsProfileName = Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9_-]+$")]
+_AwsRegion = Annotated[str, StringConstraints(pattern=r"^[a-z]{2}-[a-z]+-\d+$")]
+_AwsAccountId = Annotated[str, StringConstraints(pattern=r"^\d{12}$")]
+_AwsSsoUrl = Annotated[str, StringConstraints(pattern=r"^https://[a-zA-Z0-9.-]+(?:/[a-zA-Z0-9._/-]*)?$")]
+_AwsSsoRoleName = Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9_.-]+$", min_length=1)]
+_AwsOpRef = Annotated[str, StringConstraints(pattern=r"^op://.+$")]
+_AwsOutput = Literal["json", "yaml", "yaml-stream", "text", "table"]
+
+
+class _AwsProfileBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: _AwsProfileName
+    region: _AwsRegion
+    output: _AwsOutput = "json"
+
+
+class AwsStaticProfile(_AwsProfileBase):
+    type: Literal["static"]
+    access_key_id: _AwsOpRef
+    secret_access_key: _AwsOpRef
+
+
+class AwsSsoProfile(_AwsProfileBase):
+    type: Literal["sso"]
+    sso_start_url: _AwsSsoUrl
+    sso_region: _AwsRegion
+    sso_account_id: _AwsAccountId
+    sso_role_name: _AwsSsoRoleName
+
+
+AwsProfile = Annotated[AwsStaticProfile | AwsSsoProfile, Field(discriminator="type")]
+
+
+class AwsConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    default_profile: _AwsProfileName
+    profiles: list[AwsProfile]
+
+    @model_validator(mode="after")
+    def _default_must_exist(self) -> AwsConfig:
+        names = [p.name for p in self.profiles]
+        if len(names) != len(set(names)):
+            raise ValueError("Duplicate AWS profile names")
+        if self.default_profile not in names:
+            raise ValueError(
+                f"default_profile {self.default_profile!r} not found in profiles"
+            )
+        return self
 _DANGEROUS_ENV_KEYS = frozenset(
     {
         "LD_PRELOAD",
@@ -47,7 +105,7 @@ class Preset(BaseModel):
     name: str
     description: str
     provider: str
-    aws_profile: str = ""
+    aws: AwsConfig | None = None
     github_account: str
     ssh_key: str = "id_ed25519"
     color_scheme: str = "gruvbox"
@@ -103,7 +161,7 @@ class Preset(BaseModel):
             raise ValueError(msg)
         return v
 
-    @field_validator("aws_profile", "color_scheme", "node_version", "python_version", "mcp_profile")
+    @field_validator("color_scheme", "node_version", "python_version", "mcp_profile")
     @classmethod
     def validate_safe_string(cls, v: str) -> str:
         """Reject values with shell metacharacters."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,261 +7,290 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
 
 from devbox.auth import (
-    _validate_aws_values,
+    _validate_aws_keys,
     inject_auth,
     inject_aws_auth,
+    render_aws_files,
 )
 from devbox.exceptions import AuthError
 from devbox.presets import Preset
 
-# Valid AWS test values that pass regex validation
 _VALID_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
 _VALID_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-_VALID_REGION = "us-west-2"
-_VALID_REGION_ALT = "us-east-1"
-_VALID_REGION_EU = "eu-west-1"
+_OP_ACCESS = "op://Dev/acme/access_key_id"
+_OP_SECRET = "op://Dev/acme/secret_access_key"
 
 
-def _make_preset(
-    provider: str = "local",
-    aws_profile: str = "",
-) -> Preset:
-    """Create a minimal Preset for testing."""
-    return Preset(
-        name="test",
-        description="test preset",
-        provider=provider,
-        aws_profile=aws_profile,
-        github_account="octocat",
-    )
+def _static_profile(name: str = "acme", region: str = "us-east-1") -> dict[str, Any]:
+    return {
+        "name": name,
+        "type": "static",
+        "region": region,
+        "access_key_id": _OP_ACCESS,
+        "secret_access_key": _OP_SECRET,
+    }
 
 
-class TestInjectAwsAuth:
-    def test_writes_aws_config_and_credentials(self, tmp_path: Path, mocker: MockerFixture) -> None:
+def _sso_profile(name: str = "splash-dev") -> dict[str, Any]:
+    return {
+        "name": name,
+        "type": "sso",
+        "region": "us-east-1",
+        "sso_start_url": "https://splash.awsapps.com/start",
+        "sso_region": "us-east-1",
+        "sso_account_id": "123456789012",
+        "sso_role_name": "DeveloperAccess",
+    }
+
+
+def _make_preset(aws: dict[str, Any] | None = None, provider: str = "local") -> Preset:
+    data: dict[str, Any] = {
+        "name": "test",
+        "description": "test preset",
+        "provider": provider,
+        "github_account": "octocat",
+    }
+    if aws is not None:
+        data["aws"] = aws
+    return Preset(**data)
+
+
+class TestInjectAwsAuthNoBlock:
+    def test_noop_when_no_aws_block(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        mock_chown = mocker.patch("devbox.auth.chown_path")
+        preset = _make_preset(aws=None)
+        result = inject_aws_auth(tmp_path, preset, "dx-test")
+        assert result == []
+        assert not (tmp_path / ".aws").exists()
+        mock_chown.assert_not_called()
+
+
+class TestInjectAwsAuthStatic:
+    def _prep(self, mocker: MockerFixture) -> None:
         mocker.patch(
             "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, _VALID_REGION],
+            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY],
         )
         mocker.patch("devbox.auth.chown_path")
 
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
-        inject_aws_auth(tmp_path, preset, "dx-test")
+    def test_writes_config_and_credentials(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        self._prep(mocker)
+        preset = _make_preset(
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
+        )
+        sso = inject_aws_auth(tmp_path, preset, "dx-test")
+        assert sso == []
 
         config = (tmp_path / ".aws" / "config").read_text(encoding="utf-8")
-        assert "[profile default]" in config
-        assert f"region = {_VALID_REGION}" in config
+        assert "[profile acme]" in config
+        assert "region = us-east-1" in config
+        assert "output = json" in config
 
         creds = (tmp_path / ".aws" / "credentials").read_text(encoding="utf-8")
-        assert "[default]" in creds
+        assert "[acme]" in creds
         assert f"aws_access_key_id = {_VALID_ACCESS_KEY}" in creds
         assert f"aws_secret_access_key = {_VALID_SECRET_KEY}" in creds
+        assert "[default]" not in creds
 
-    def test_aws_dir_permissions_0700(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        mocker.patch(
-            "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, _VALID_REGION_ALT],
+    def test_dir_0700_files_0600(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        self._prep(mocker)
+        preset = _make_preset(
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
         )
-        mocker.patch("devbox.auth.chown_path")
-
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
         inject_aws_auth(tmp_path, preset, "dx-test")
 
-        mode = os.stat(tmp_path / ".aws").st_mode & 0o777
-        assert mode == 0o700
-
-    def test_aws_files_permissions_0600(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        mocker.patch(
-            "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, _VALID_REGION_ALT],
-        )
-        mocker.patch("devbox.auth.chown_path")
-
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
-        inject_aws_auth(tmp_path, preset, "dx-test")
-
+        assert os.stat(tmp_path / ".aws").st_mode & 0o777 == 0o700
         for name in ("config", "credentials"):
-            mode = os.stat(tmp_path / ".aws" / name).st_mode & 0o777
-            assert mode == 0o600, f"{name} should be 0600"
+            assert os.stat(tmp_path / ".aws" / name).st_mode & 0o777 == 0o600
 
     def test_chowns_aws_dir(self, tmp_path: Path, mocker: MockerFixture) -> None:
         mocker.patch(
             "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, _VALID_REGION_ALT],
+            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY],
         )
         mock_chown = mocker.patch("devbox.auth.chown_path")
-
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
+        preset = _make_preset(
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
+        )
         inject_aws_auth(tmp_path, preset, "dx-test")
-
         mock_chown.assert_called_once_with(tmp_path / ".aws", "dx-test")
 
-    def test_raises_auth_error_on_wrong_provider(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
-        preset = _make_preset(provider="local")
-        with pytest.raises(AuthError, match="requires provider 'aws'"):
-            inject_aws_auth(tmp_path, preset, "dx-test")
-
-    def test_raises_auth_error_when_aws_profile_empty(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
-        preset = _make_preset(provider="aws", aws_profile="")
-        with pytest.raises(AuthError, match="aws_profile is required"):
-            inject_aws_auth(tmp_path, preset, "dx-test")
-
-    def test_raises_auth_error_on_secret_failure(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
-        mocker.patch(
+    def test_resolves_op_refs(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        mock_get = mocker.patch(
             "devbox.auth.get_secret",
-            side_effect=Exception("vault locked"),
+            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY],
         )
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
+        mocker.patch("devbox.auth.chown_path")
+        preset = _make_preset(
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
+        )
+        inject_aws_auth(tmp_path, preset, "dx-test")
+        mock_get.assert_any_call(_OP_ACCESS)
+        mock_get.assert_any_call(_OP_SECRET)
+        assert mock_get.call_count == 2
+
+    def test_raises_on_secret_failure(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        mocker.patch("devbox.auth.get_secret", side_effect=Exception("vault locked"))
+        preset = _make_preset(
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
+        )
         with pytest.raises(AuthError, match="Failed to resolve AWS credentials"):
             inject_aws_auth(tmp_path, preset, "dx-test")
 
-    def test_resolves_correct_op_references(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        mock_get = mocker.patch(
-            "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, _VALID_REGION_EU],
-        )
-        mocker.patch("devbox.auth.chown_path")
-
-        preset = _make_preset(provider="aws", aws_profile="acme-prod")
-        inject_aws_auth(tmp_path, preset, "dx-test")
-
-        assert mock_get.call_count == 3
-        mock_get.assert_any_call("op://Development/acme-prod/access-key-id")
-        mock_get.assert_any_call("op://Development/acme-prod/secret-access-key")
-        mock_get.assert_any_call("op://Development/acme-prod/region")
-
-    def test_raises_auth_error_on_write_failure(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
+    def test_rejects_invalid_access_key(self, tmp_path: Path, mocker: MockerFixture) -> None:
         mocker.patch(
-            "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, _VALID_REGION_ALT],
+            "devbox.auth.get_secret", side_effect=["bad-key", _VALID_SECRET_KEY]
         )
         mocker.patch("devbox.auth.chown_path")
-        mocker.patch("pathlib.Path.mkdir", side_effect=PermissionError("denied"))
-
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
-        with pytest.raises(AuthError, match="Failed to write AWS credentials"):
+        preset = _make_preset(
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
+        )
+        with pytest.raises(AuthError, match="Invalid AWS access key"):
             inject_aws_auth(tmp_path, preset, "dx-test")
 
-    def test_config_contains_output_json(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        mocker.patch(
-            "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, _VALID_REGION],
-        )
-        mocker.patch("devbox.auth.chown_path")
 
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
-        inject_aws_auth(tmp_path, preset, "dx-test")
+class TestInjectAwsAuthSso:
+    def test_writes_sso_block_to_config(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        mocker.patch("devbox.auth.chown_path")
+        preset = _make_preset(
+            aws={"default_profile": "splash-dev", "profiles": [_sso_profile()]},
+        )
+        sso = inject_aws_auth(tmp_path, preset, "dx-test")
+        assert sso == ["splash-dev"]
 
         config = (tmp_path / ".aws" / "config").read_text(encoding="utf-8")
-        assert "output = json" in config
+        assert "[profile splash-dev]" in config
+        assert "sso_start_url = https://splash.awsapps.com/start" in config
+        assert "sso_account_id = 123456789012" in config
+        assert "sso_role_name = DeveloperAccess" in config
+
+        # Credentials file is not written when no static profiles are present.
+        assert not (tmp_path / ".aws" / "credentials").exists()
+
+    def test_no_op_calls_for_sso_only(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        mock_get = mocker.patch("devbox.auth.get_secret")
+        mocker.patch("devbox.auth.chown_path")
+        preset = _make_preset(
+            aws={"default_profile": "splash-dev", "profiles": [_sso_profile()]},
+        )
+        inject_aws_auth(tmp_path, preset, "dx-test")
+        mock_get.assert_not_called()
 
 
-class TestValidateAwsValues:
-    def test_valid_values_pass(self) -> None:
-        # Should not raise
-        _validate_aws_values(_VALID_REGION, _VALID_ACCESS_KEY, _VALID_SECRET_KEY)
-
-    def test_invalid_region_raises(self) -> None:
-        with pytest.raises(AuthError, match="Invalid AWS region format"):
-            _validate_aws_values("not-a-region!", _VALID_ACCESS_KEY, _VALID_SECRET_KEY)
-
-    def test_region_with_uppercase_raises(self) -> None:
-        with pytest.raises(AuthError, match="Invalid AWS region format"):
-            _validate_aws_values("US-WEST-2", _VALID_ACCESS_KEY, _VALID_SECRET_KEY)
-
-    def test_empty_region_raises(self) -> None:
-        with pytest.raises(AuthError, match="Invalid AWS region format"):
-            _validate_aws_values("", _VALID_ACCESS_KEY, _VALID_SECRET_KEY)
-
-    def test_invalid_access_key_raises(self) -> None:
-        with pytest.raises(AuthError, match="Invalid AWS access key format"):
-            _validate_aws_values(_VALID_REGION, "short", _VALID_SECRET_KEY)
-
-    def test_access_key_with_lowercase_raises(self) -> None:
-        with pytest.raises(AuthError, match="Invalid AWS access key format"):
-            _validate_aws_values(_VALID_REGION, "akiaiosfodnn7example", _VALID_SECRET_KEY)
-
-    def test_invalid_secret_key_raises(self) -> None:
-        with pytest.raises(AuthError, match="Invalid AWS secret key format"):
-            _validate_aws_values(_VALID_REGION, _VALID_ACCESS_KEY, "short")
-
-    def test_secret_key_with_special_chars_raises(self) -> None:
-        with pytest.raises(AuthError, match="Invalid AWS secret key format"):
-            _validate_aws_values(_VALID_REGION, _VALID_ACCESS_KEY, "x" * 16 + "!@#$%^&*()")
-
-    def test_inject_aws_rejects_invalid_region(self, tmp_path: Path, mocker: MockerFixture) -> None:
+class TestInjectAwsAuthMixed:
+    def test_static_plus_sso(self, tmp_path: Path, mocker: MockerFixture) -> None:
         mocker.patch(
             "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY, "INVALID"],
+            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY],
         )
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
-        with pytest.raises(AuthError, match="Invalid AWS region format"):
-            inject_aws_auth(tmp_path, preset, "dx-test")
+        mocker.patch("devbox.auth.chown_path")
+        preset = _make_preset(
+            aws={
+                "default_profile": "acme",
+                "profiles": [_static_profile(), _sso_profile()],
+            },
+        )
+        sso = inject_aws_auth(tmp_path, preset, "dx-test")
+        assert sso == ["splash-dev"]
 
-    def test_inject_aws_rejects_invalid_access_key(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
-        mocker.patch(
-            "devbox.auth.get_secret",
-            side_effect=["bad", _VALID_SECRET_KEY, _VALID_REGION],
-        )
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
-        with pytest.raises(AuthError, match="Invalid AWS access key format"):
-            inject_aws_auth(tmp_path, preset, "dx-test")
+        config = (tmp_path / ".aws" / "config").read_text(encoding="utf-8")
+        assert "[profile acme]" in config
+        assert "[profile splash-dev]" in config
 
-    def test_inject_aws_rejects_invalid_secret_key(
-        self, tmp_path: Path, mocker: MockerFixture
-    ) -> None:
-        mocker.patch(
-            "devbox.auth.get_secret",
-            side_effect=[_VALID_ACCESS_KEY, "bad", _VALID_REGION],
-        )
-        preset = _make_preset(provider="aws", aws_profile="my-profile")
-        with pytest.raises(AuthError, match="Invalid AWS secret key format"):
-            inject_aws_auth(tmp_path, preset, "dx-test")
+        creds = (tmp_path / ".aws" / "credentials").read_text(encoding="utf-8")
+        assert "[acme]" in creds
+        assert "splash-dev" not in creds
+
+
+class TestValidateAwsKeys:
+    def test_valid_passes(self) -> None:
+        _validate_aws_keys(_VALID_ACCESS_KEY, _VALID_SECRET_KEY)
+
+    def test_bad_access_key_raises(self) -> None:
+        with pytest.raises(AuthError, match="access key"):
+            _validate_aws_keys("short", _VALID_SECRET_KEY)
+
+    def test_bad_secret_key_raises(self) -> None:
+        with pytest.raises(AuthError, match="secret key"):
+            _validate_aws_keys(_VALID_ACCESS_KEY, "short")
 
 
 class TestInjectAuth:
-    def test_local_provider_is_noop(self, tmp_path: Path, mocker: MockerFixture) -> None:
+    def test_local_provider_no_aws(self, tmp_path: Path, mocker: MockerFixture) -> None:
         preset = _make_preset(provider="local")
-        inject_auth(tmp_path, preset, "dx-test")  # should not raise
+        assert inject_auth(tmp_path, preset, "dx-test") == []
 
-    def test_dispatches_to_aws_for_aws(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        mock_aws = mocker.patch("devbox.auth.inject_aws_auth")
-
-        preset = _make_preset(provider="aws", aws_profile="prof")
-        inject_auth(tmp_path, preset, "dx-test")
-
-        mock_aws.assert_called_once_with(tmp_path, preset, "dx-test")
-
-    def test_raises_auth_error_for_unknown_provider(
+    def test_local_provider_with_aws_still_injects(
         self, tmp_path: Path, mocker: MockerFixture
     ) -> None:
-        # Force an invalid provider by bypassing validation
+        mocker.patch(
+            "devbox.auth.get_secret",
+            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY],
+        )
+        mocker.patch("devbox.auth.chown_path")
+        preset = _make_preset(
+            provider="local",
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
+        )
+        inject_auth(tmp_path, preset, "dx-test")
+        assert (tmp_path / ".aws" / "credentials").exists()
+
+    def test_unknown_provider_raises(self, tmp_path: Path) -> None:
         preset = _make_preset(provider="local")
         object.__setattr__(preset, "provider", "gcp")
-
         with pytest.raises(AuthError, match="Unknown provider"):
             inject_auth(tmp_path, preset, "dx-test")
 
-    def test_propagates_aws_error(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        mocker.patch(
-            "devbox.auth.inject_aws_auth",
-            side_effect=AuthError("aws boom"),
-        )
 
-        preset = _make_preset(provider="aws", aws_profile="prof")
-        with pytest.raises(AuthError, match="aws boom"):
-            inject_auth(tmp_path, preset, "dx-test")
+class TestRenderAwsFiles:
+    def test_render_static_only(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "devbox.auth.get_secret",
+            side_effect=[_VALID_ACCESS_KEY, _VALID_SECRET_KEY],
+        )
+        preset = _make_preset(
+            aws={"default_profile": "acme", "profiles": [_static_profile()]},
+        )
+        config, creds, sso = render_aws_files(preset)
+        assert sso == []
+        assert "[profile acme]" in config
+        assert f"aws_access_key_id = {_VALID_ACCESS_KEY}" in creds
+
+
+class TestLogSsoHints:
+    def test_emits_login_hint_per_profile(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        from devbox.auth import log_sso_hints
+
+        with caplog.at_level(logging.INFO, logger="devbox.auth"):
+            log_sso_hints(["p1", "p2"])
+
+        messages = [r.getMessage() for r in caplog.records]
+        joined = "\n".join(messages)
+        assert "aws sso login --profile p1" in joined
+        assert "aws sso login --profile p2" in joined
+
+    def test_empty_list_is_noop(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        from devbox.auth import log_sso_hints
+
+        with caplog.at_level(logging.INFO, logger="devbox.auth"):
+            log_sso_hints([])
+
+        assert caplog.records == []
+
+
+class TestRenderAwsFilesNoBlock:
+    def test_returns_empty_when_no_aws_block(self) -> None:
+        from devbox.auth import AwsRender
+
+        preset = _make_preset(aws=None)
+        assert render_aws_files(preset) == AwsRender("", "", [])

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -22,6 +22,8 @@ from devbox.bootstrap import (
     install_nvm,
     install_pip_globals,
     install_pyenv,
+    refresh_aws_config,
+    refresh_devbox_env,
     run_loadout,
     setup_gh_auth,
 )
@@ -485,3 +487,232 @@ class TestRunLoadout:
         preset = self._preset(loadout_orgs=[])
         run_loadout(HOME, preset, USERNAME)
         mock_run.assert_not_called()
+
+
+class TestRefreshAwsConfig:
+    """refresh_aws_config pushes ~/.aws/{config,credentials} via SSH."""
+
+    _AK = "AKIAIOSFODNN7EXAMPLE"
+    _SK = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+    def _preset_with_aws(self, profiles: list[dict]) -> Preset:
+        return _preset(
+            aws={"default_profile": profiles[0]["name"], "profiles": profiles},
+        )
+
+    def test_noop_when_no_aws_block(self, mocker: MockerFixture) -> None:
+
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run")
+        preset = _preset()
+        result = refresh_aws_config(HOME, preset, USERNAME)
+        assert result == []
+        mock_run.assert_not_called()
+
+    def test_writes_static_profile_via_ssh(self, mocker: MockerFixture) -> None:
+
+        mocker.patch("devbox.auth.get_secret", side_effect=[self._AK, self._SK])
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+
+        preset = self._preset_with_aws(
+            [
+                {
+                    "name": "acme",
+                    "type": "static",
+                    "region": "us-east-1",
+                    "access_key_id": "op://V/I/access_key_id",
+                    "secret_access_key": "op://V/I/secret_access_key",
+                }
+            ]
+        )
+        sso = refresh_aws_config(HOME, preset, USERNAME)
+        assert sso == []
+        # mkdir + config + credentials = 3 calls
+        assert mock_run.call_count == 3
+        cmds = [call.args[0] for call in mock_run.call_args_list]
+        assert any("mkdir -p ~/.aws" in " ".join(c) for c in cmds)
+        assert any("~/.aws/config" in " ".join(c) for c in cmds)
+        assert any("~/.aws/credentials" in " ".join(c) for c in cmds)
+
+    def test_sso_profile_returned(self, mocker: MockerFixture) -> None:
+
+        mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+        preset = self._preset_with_aws(
+            [
+                {
+                    "name": "splash",
+                    "type": "sso",
+                    "region": "us-east-1",
+                    "sso_start_url": "https://splash.awsapps.com/start",
+                    "sso_region": "us-east-1",
+                    "sso_account_id": "123456789012",
+                    "sso_role_name": "Dev",
+                }
+            ]
+        )
+        sso = refresh_aws_config(HOME, preset, USERNAME)
+        assert sso == ["splash"]
+
+    def test_heredoc_body_contains_rendered_content(self, mocker: MockerFixture) -> None:
+
+        mocker.patch("devbox.auth.get_secret", side_effect=[self._AK, self._SK])
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+
+        preset = self._preset_with_aws(
+            [
+                {
+                    "name": "acme",
+                    "type": "static",
+                    "region": "us-west-2",
+                    "access_key_id": "op://V/I/access_key_id",
+                    "secret_access_key": "op://V/I/secret_access_key",
+                }
+            ]
+        )
+        refresh_aws_config(HOME, preset, USERNAME)
+
+        cmds = [call.args[0] for call in mock_run.call_args_list]
+        config_cmd = next(c for c in cmds if "~/.aws/config" in " ".join(c))
+        creds_cmd = next(c for c in cmds if "~/.aws/credentials" in " ".join(c))
+        config_body = config_cmd[-1]
+        creds_body = creds_cmd[-1]
+
+        assert "[profile acme]" in config_body
+        assert "region = us-west-2" in config_body
+        assert "[acme]" in creds_body
+        assert f"aws_access_key_id = {self._AK}" in creds_body
+        assert f"aws_secret_access_key = {self._SK}" in creds_body
+
+    def test_skips_credentials_when_sso_only(self, mocker: MockerFixture) -> None:
+
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+        preset = self._preset_with_aws(
+            [
+                {
+                    "name": "splash",
+                    "type": "sso",
+                    "region": "us-east-1",
+                    "sso_start_url": "https://splash.awsapps.com/start",
+                    "sso_region": "us-east-1",
+                    "sso_account_id": "123456789012",
+                    "sso_role_name": "Dev",
+                }
+            ]
+        )
+        refresh_aws_config(HOME, preset, USERNAME)
+
+        cmds = [" ".join(call.args[0]) for call in mock_run.call_args_list]
+        assert any("~/.aws/config" in c for c in cmds)
+        assert not any("~/.aws/credentials" in c for c in cmds)
+
+    def test_ssh_failure_raises(self, mocker: MockerFixture) -> None:
+
+        mocker.patch("devbox.auth.get_secret", side_effect=[self._AK, self._SK])
+        mocker.patch("devbox.bootstrap.subprocess.run", return_value=_fail(code=255))
+
+        preset = self._preset_with_aws(
+            [
+                {
+                    "name": "acme",
+                    "type": "static",
+                    "region": "us-east-1",
+                    "access_key_id": "op://V/I/access_key_id",
+                    "secret_access_key": "op://V/I/secret_access_key",
+                }
+            ]
+        )
+        with pytest.raises(BootstrapError):
+            refresh_aws_config(HOME, preset, USERNAME)
+
+
+class TestRefreshDevboxEnv:
+    """refresh_devbox_env pushes .devbox-env via base64 over SSH."""
+
+    def test_noop_when_nothing_resolved(self, mocker: MockerFixture) -> None:
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run")
+        preset = _preset()  # no env_vars, no aws
+        refresh_devbox_env(HOME, preset, USERNAME)
+        mock_run.assert_not_called()
+
+    def test_writes_aws_profile(self, mocker: MockerFixture) -> None:
+        import base64
+
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+        preset = _preset(
+            aws={
+                "default_profile": "acme",
+                "profiles": [
+                    {
+                        "name": "acme",
+                        "type": "static",
+                        "region": "us-east-1",
+                        "access_key_id": "op://V/I/access_key_id",
+                        "secret_access_key": "op://V/I/secret_access_key",
+                    }
+                ],
+            },
+        )
+        refresh_devbox_env(HOME, preset, USERNAME)
+
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args_list[0].args[0]
+        remote = cmd[-1]
+        assert "~/.devbox-env" in remote
+        assert "chmod 0600" in remote
+        assert "base64 -d" in remote
+        # Extract base64 payload and confirm it decodes to the expected export.
+        payload = remote.split("echo ")[1].split(" |")[0]
+        decoded = base64.b64decode(payload).decode("utf-8")
+        assert "AWS_PROFILE=" in decoded and "acme" in decoded
+
+    def test_resolves_env_vars(self, mocker: MockerFixture) -> None:
+        import base64
+
+        mocker.patch(
+            "devbox.onepassword.resolve_env_vars",
+            return_value={"TOKEN": "s3cret"},
+        )
+        mock_run = mocker.patch("devbox.bootstrap.subprocess.run", return_value=_ok())
+        preset = _preset(env_vars={"TOKEN": "op://V/I/F"})
+        refresh_devbox_env(HOME, preset, USERNAME)
+
+        cmd = mock_run.call_args_list[0].args[0]
+        payload = cmd[-1].split("echo ")[1].split(" |")[0]
+        decoded = base64.b64decode(payload).decode("utf-8")
+        assert "export TOKEN=" in decoded
+
+    def test_op_error_raises_bootstrap_error(self, mocker: MockerFixture) -> None:
+        from devbox.exceptions import OnePasswordError
+
+        mocker.patch(
+            "devbox.onepassword.resolve_env_vars",
+            side_effect=OnePasswordError("vault locked"),
+        )
+        preset = _preset(env_vars={"TOKEN": "op://V/I/F"})
+        with pytest.raises(BootstrapError, match="refresh env"):
+            refresh_devbox_env(HOME, preset, USERNAME)
+
+
+class TestRefreshAwsConfigErrorPath:
+    def test_render_failure_raises_bootstrap_error(self, mocker: MockerFixture) -> None:
+        from devbox.exceptions import AuthError
+
+        mocker.patch(
+            "devbox.bootstrap.render_aws_files",
+            side_effect=AuthError("op boom"),
+        )
+        preset = _preset(
+            aws={
+                "default_profile": "acme",
+                "profiles": [
+                    {
+                        "name": "acme",
+                        "type": "static",
+                        "region": "us-east-1",
+                        "access_key_id": "op://V/I/access_key_id",
+                        "secret_access_key": "op://V/I/secret_access_key",
+                    }
+                ],
+            },
+        )
+        with pytest.raises(BootstrapError, match="refresh AWS config"):
+            refresh_aws_config(HOME, preset, USERNAME)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -79,7 +79,7 @@ class TestPresetDefaults:
     def test_defaults_applied(self) -> None:
         preset = Preset(**VALID_PRESET)
         assert preset.version == 1
-        assert preset.aws_profile == ""
+        assert preset.aws is None
         assert preset.color_scheme == "gruvbox"
         assert preset.node_version == "lts"
         assert preset.python_version == "3.12"
@@ -95,7 +95,6 @@ class TestPresetDefaults:
             "name": "full",
             "description": "Full preset",
             "provider": "aws",
-            "aws_profile": "my-profile",
             "github_account": "user",
             "color_scheme": "catppuccin",
             "node_version": "20",
@@ -249,16 +248,6 @@ class TestPresetFieldValidation:
             preset = validate_preset(data)
             assert preset.provider == provider
 
-    def test_aws_profile_injection_rejected(self) -> None:
-        data = {**VALID_PRESET, "aws_profile": "profile; echo pwned"}
-        with pytest.raises(PresetError, match="validation failed"):
-            validate_preset(data)
-
-    def test_valid_aws_profile_accepted(self) -> None:
-        data = {**VALID_PRESET, "aws_profile": "my-profile_v2"}
-        preset = validate_preset(data)
-        assert preset.aws_profile == "my-profile_v2"
-
     def test_node_version_injection_rejected(self) -> None:
         data = {**VALID_PRESET, "node_version": "20 && rm -rf /"}
         with pytest.raises(PresetError, match="validation failed"):
@@ -291,5 +280,118 @@ class TestPresetFieldValidation:
 
     def test_brew_extras_non_list_rejected(self) -> None:
         data = {**VALID_PRESET, "brew_extras": "not-a-list"}
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+
+def _static_profile(name: str = "acme") -> dict[str, Any]:
+    return {
+        "name": name,
+        "type": "static",
+        "region": "us-east-1",
+        "access_key_id": "op://Vault/Item/access_key_id",
+        "secret_access_key": "op://Vault/Item/secret_access_key",
+    }
+
+
+def _sso_profile(name: str = "splash-dev") -> dict[str, Any]:
+    return {
+        "name": name,
+        "type": "sso",
+        "region": "us-east-1",
+        "sso_start_url": "https://splash.awsapps.com/start",
+        "sso_region": "us-east-1",
+        "sso_account_id": "123456789012",
+        "sso_role_name": "DeveloperAccess",
+    }
+
+
+class TestAwsBlock:
+    def test_valid_static_profile(self) -> None:
+        data = {**VALID_PRESET, "aws": {"default_profile": "acme", "profiles": [_static_profile()]}}
+        preset = validate_preset(data)
+        assert preset.aws is not None
+        assert preset.aws.default_profile == "acme"
+        assert preset.aws.profiles[0].name == "acme"
+
+    def test_valid_sso_profile(self) -> None:
+        data = {
+            **VALID_PRESET,
+            "aws": {"default_profile": "splash-dev", "profiles": [_sso_profile()]},
+        }
+        preset = validate_preset(data)
+        assert preset.aws.profiles[0].type == "sso"
+
+    def test_valid_mixed_profiles(self) -> None:
+        data = {
+            **VALID_PRESET,
+            "aws": {
+                "default_profile": "acme",
+                "profiles": [_static_profile(), _sso_profile()],
+            },
+        }
+        preset = validate_preset(data)
+        assert len(preset.aws.profiles) == 2
+
+    def test_default_profile_must_exist(self) -> None:
+        data = {
+            **VALID_PRESET,
+            "aws": {"default_profile": "missing", "profiles": [_static_profile()]},
+        }
+        with pytest.raises(PresetError, match="not found in profiles"):
+            validate_preset(data)
+
+    def test_duplicate_profile_names_rejected(self) -> None:
+        data = {
+            **VALID_PRESET,
+            "aws": {
+                "default_profile": "acme",
+                "profiles": [_static_profile(), _static_profile()],
+            },
+        }
+        with pytest.raises(PresetError, match="Duplicate"):
+            validate_preset(data)
+
+    def test_unknown_profile_type_rejected(self) -> None:
+        bad = {**_static_profile(), "type": "magic"}
+        data = {**VALID_PRESET, "aws": {"default_profile": "acme", "profiles": [bad]}}
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+    def test_static_requires_op_ref(self) -> None:
+        bad = {**_static_profile(), "access_key_id": "AKIA-literal-not-allowed"}
+        data = {**VALID_PRESET, "aws": {"default_profile": "acme", "profiles": [bad]}}
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+    def test_bad_region_rejected(self) -> None:
+        bad = {**_static_profile(), "region": "US-EAST-1"}
+        data = {**VALID_PRESET, "aws": {"default_profile": "acme", "profiles": [bad]}}
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+    def test_bad_sso_account_id_rejected(self) -> None:
+        bad = {**_sso_profile(), "sso_account_id": "12345"}
+        data = {**VALID_PRESET, "aws": {"default_profile": "splash-dev", "profiles": [bad]}}
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+    def test_bad_profile_name_rejected(self) -> None:
+        bad = {**_static_profile(), "name": "acme; rm -rf /"}
+        data = {
+            **VALID_PRESET,
+            "aws": {"default_profile": "acme", "profiles": [bad]},
+        }
+        with pytest.raises(PresetError, match="validation failed"):
+            validate_preset(data)
+
+    def test_empty_profiles_with_default_rejected(self) -> None:
+        data = {**VALID_PRESET, "aws": {"default_profile": "acme", "profiles": []}}
+        with pytest.raises(PresetError, match="not found in profiles"):
+            validate_preset(data)
+
+    def test_extra_field_on_profile_rejected(self) -> None:
+        bad = {**_static_profile(), "extra": "nope"}
+        data = {**VALID_PRESET, "aws": {"default_profile": "acme", "profiles": [bad]}}
         with pytest.raises(PresetError, match="validation failed"):
             validate_preset(data)


### PR DESCRIPTION
## Summary
- Replace single `aws_profile` string with structured `aws:` block supporting multiple profiles per devbox
- Static profiles resolve `op://` refs on host at create/refresh; SSO profiles write config-only blocks
- `AWS_PROFILE` is set from `default_profile` via `.devbox-env` (no `[default]` section written)
- Refresh overwrites `~/.aws/{config,credentials}` and `.devbox-env` so stale profiles don't leak

**Breaking change:** existing presets using `aws_profile` must migrate to the new `aws:` block.

Closes #54.

## Test plan
- [x] Unit tests pass (607 passing, coverage 87.53%)
- [x] Ruff clean
- [ ] Migrate Cardonomics preset to new schema
- [ ] Run \`devbox refresh cardonomics\` and verify \`aws sts get-caller-identity\` works inside devbox
- [ ] Verify SSO hint is logged for SSO profiles