### PR TITLE
feat: track incomplete bootstraps and let refresh repair them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add concurrency control to CI workflows
 
 ### Added
+- `incomplete` registry status for devboxes whose `run_loadout` and/or `clone_repos` failed during create (typically GitHub SSH throttling). Surfaced in `devbox list` and as a warning summary on `create`/`rebuild`, with a clear hint to run `devbox refresh` to retry.
+- `devbox refresh` now accepts `incomplete` boxes and re-runs the failed clone phases before the regular refresh logic. On success the status is promoted to `ready`; on failure it raises with a recoverable error (no FileNotFoundError on missing `~/.dotfiles`). `devbox refresh --all` includes `incomplete` boxes.
 - `devbox refresh <name>` and `devbox refresh --all` to push current dotfiles/config and reinstall preset `brew_extras` on existing devboxes without destroying state. Runs entirely over SSH as the devbox user (no host sudo). `--with-globals` opt-in reinstalls `npm_globals`/`pip_globals`. Loadout Brewfile changes require `rebuild`. (#49, #51)
 - SPDX license headers and copyright notices on all source files
 - CODE_OF_CONDUCT.md (Contributor Covenant v2.1)

--- a/src/devbox/cli.py
+++ b/src/devbox/cli.py
@@ -30,6 +30,7 @@ _STATUS_ICONS: dict[str, str] = {
     "unreachable": "[red]❌ unreachable[/red]",
     "unknown": "[dim]— unknown[/dim]",
     "creating": "[blue]🔧 creating[/blue]",
+    "incomplete": "[yellow]⚠️  incomplete[/yellow]",
     "nuking": "[red]💀 nuking[/red]",
 }
 
@@ -69,8 +70,22 @@ def create(name: str, preset: str | None, dry_run: bool) -> None:
                 result = create_devbox(name, preset, on_step=_on_step)
             finally:
                 status.stop()
-            console.print(f"[green]✓[/green] Devbox [bold]{name}[/bold] created successfully")
-            console.print(f"  Connect: [cyan]ssh dx-{name}[/cyan]")
+            warnings = result.get("bootstrap_warnings") or []
+            if warnings:
+                console.print(
+                    f"[yellow]⚠[/yellow] Devbox [bold]{name}[/bold] created with warnings:"
+                )
+                for w in warnings:
+                    console.print(f"  [yellow]•[/yellow] {w}")
+                console.print(
+                    f"  Some bootstrap steps failed (often GitHub SSH throttling). "
+                    f"Wait a few minutes, then run "
+                    f"[cyan]devbox refresh {name}[/cyan] to retry."
+                )
+                console.print(f"  Connect: [cyan]ssh dx-{name}[/cyan]")
+            else:
+                console.print(f"[green]✓[/green] Devbox [bold]{name}[/bold] created successfully")
+                console.print(f"  Connect: [cyan]ssh dx-{name}[/cyan]")
     except (DevboxError, ValueError) as exc:
         console.print(f"[red]✗[/red] {exc}")
         sys.exit(1)
@@ -82,8 +97,19 @@ def rebuild(name: str) -> None:
     """Tear down and recreate an existing devbox."""
     try:
         with console.status(f"[bold]Rebuilding devbox {name!r}..."):
-            rebuild_devbox(name)
-        console.print(f"[green]✓[/green] Devbox [bold]{name}[/bold] rebuilt successfully")
+            result = rebuild_devbox(name)
+        warnings = result.get("bootstrap_warnings") or []
+        if warnings:
+            console.print(f"[yellow]⚠[/yellow] Devbox [bold]{name}[/bold] rebuilt with warnings:")
+            for w in warnings:
+                console.print(f"  [yellow]•[/yellow] {w}")
+            console.print(
+                f"  Some bootstrap steps failed (often GitHub SSH throttling). "
+                f"Wait a few minutes, then run "
+                f"[cyan]devbox refresh {name}[/cyan] to retry."
+            )
+        else:
+            console.print(f"[green]✓[/green] Devbox [bold]{name}[/bold] rebuilt successfully")
         console.print(f"  Connect: [cyan]ssh dx-{name}[/cyan]")
     except (DevboxError, ValueError) as exc:
         console.print(f"[red]✗[/red] {exc}")
@@ -114,7 +140,12 @@ def refresh(name: str | None, all_: bool, with_globals: bool) -> None:
 
     if all_:
         registry = load_registry()
-        targets = [e.name for e in registry.devboxes if e.status == DevboxStatus.READY]
+        # Include INCOMPLETE so --all repairs half-bootstrapped boxes too.
+        targets = [
+            e.name
+            for e in registry.devboxes
+            if e.status in (DevboxStatus.READY, DevboxStatus.INCOMPLETE)
+        ]
         if not targets:
             console.print("[yellow]No ready devboxes to refresh[/yellow]")
             return

--- a/src/devbox/core.py
+++ b/src/devbox/core.py
@@ -257,7 +257,11 @@ def create_devbox(
         ssh.add_ssh_config_entry(name, preset_obj.ssh_key)
         compensation.push("remove SSH config entry", partial(ssh.remove_ssh_config_entry, name))
 
-        # Run loadout via SSH now that the devbox is accessible
+        # Run loadout via SSH now that the devbox is accessible.
+        # Failures here leave the devbox without dotfiles — track them so
+        # the final status reflects that (INCOMPLETE) and the user gets a
+        # clear recovery hint via `devbox refresh`.
+        bootstrap_warnings: list[str] = []
         if preset_obj.loadout_orgs:
             step("Running loadout (this may take several minutes)")
             try:
@@ -265,6 +269,7 @@ def create_devbox(
 
                 run_loadout(home_dir, preset_obj, username)
             except Exception as exc:
+                bootstrap_warnings.append(f"loadout: {exc}")
                 logger.warning("Loadout failed (non-fatal): %s", exc)
 
         # Create ~/Developer and clone repos. Always runs so ~/Developer
@@ -277,17 +282,21 @@ def create_devbox(
 
             clone_repos(home_dir, preset_obj, username)
         except Exception as exc:
+            bootstrap_warnings.append(f"repo clone: {exc}")
             logger.warning("Repo setup failed (non-fatal): %s", exc)
 
         step("Finalizing")
-        update_entry(name, registry_path, status=DevboxStatus.READY)
+        final_status = DevboxStatus.INCOMPLETE if bootstrap_warnings else DevboxStatus.READY
+        update_entry(name, registry_path, status=final_status)
 
     except Exception:
         compensation.rollback()
         raise
 
     updated = find_entry(name, registry_path)
-    return updated.model_dump() if updated else entry.model_dump()
+    result = updated.model_dump() if updated else entry.model_dump()
+    result["bootstrap_warnings"] = bootstrap_warnings
+    return result
 
 
 def list_devboxes(
@@ -490,7 +499,9 @@ def refresh_devbox(
 
     # Status check is best-effort: there's no registry lock, so a concurrent
     # nuke/rebuild could race. SSH will fail cleanly in that case.
-    if entry.status != DevboxStatus.READY:
+    # INCOMPLETE is allowed so refresh can repair half-bootstrapped boxes
+    # (e.g. when GitHub SSH throttling killed the initial clones).
+    if entry.status not in (DevboxStatus.READY, DevboxStatus.INCOMPLETE):
         raise DevboxError(
             f"Devbox {name!r} is not ready to refresh (status: {entry.status.value}). "
             f"Wait for it to finish, or use 'devbox list' to check."
@@ -502,12 +513,38 @@ def refresh_devbox(
 
     from devbox.bootstrap import (
         build_ssh_base,
+        clone_repos,
         install_brew_extras,
         install_npm_globals,
         install_pip_globals,
         refresh_dotfiles,
         refresh_shell_env,
+        run_loadout,
     )
+
+    # Repair phase: re-run the create-time clones if the box is INCOMPLETE.
+    # Both run_loadout and clone_repos are idempotent (skip when target exists),
+    # so this is safe even if some repos already cloned. If repair still fails
+    # (e.g. throttle window not closed), bail before refresh_dotfiles trips on
+    # missing ~/.dotfiles.
+    if entry.status == DevboxStatus.INCOMPLETE:
+        repair_warnings: list[str] = []
+        if preset_obj.loadout_orgs:
+            try:
+                run_loadout(home_dir, preset_obj, username)
+            except Exception as exc:
+                repair_warnings.append(f"loadout: {exc}")
+        try:
+            clone_repos(home_dir, preset_obj, username)
+        except Exception as exc:
+            repair_warnings.append(f"repo clone: {exc}")
+        if repair_warnings:
+            raise DevboxError(
+                "Repair failed: "
+                + "; ".join(repair_warnings)
+                + ". Wait a few minutes and retry, or rebuild."
+            )
+        update_entry(name, registry_path, status=DevboxStatus.READY)
 
     if not preset_obj.loadout_orgs and (preset_obj.brew_extras or with_globals):
         logger.warning(

--- a/src/devbox/registry.py
+++ b/src/devbox/registry.py
@@ -29,6 +29,7 @@ class DevboxStatus(StrEnum):
 
     CREATING = "creating"
     READY = "ready"
+    INCOMPLETE = "incomplete"
     NUKING = "nuking"
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -249,6 +249,10 @@ class TestCreateDevbox:
         mocker.patch("devbox.core.bootstrap_user", return_value=[])
         mocker.patch("devbox.core.write_zshrc")
         mocker.patch("devbox.core.time.sleep")
+        # run_loadout / clone_repos are imported inline inside create_devbox
+        # via `from devbox.bootstrap import …`, so patch the source module.
+        mocker.patch("devbox.bootstrap.run_loadout")
+        mocker.patch("devbox.bootstrap.clone_repos")
 
         return {
             "presets_dir": presets_dir,
@@ -366,6 +370,74 @@ class TestCreateDevbox:
         )
         mock_resolve.assert_called_once_with({"SECRET": "op://vault/item/field"})
         mock_write.assert_called_once()
+
+    def test_loadout_failure_marks_incomplete(
+        self, setup: dict[str, Any], mocker: MockerFixture
+    ) -> None:
+        """A failed run_loadout should leave the devbox in INCOMPLETE state."""
+        _make_preset_file(setup["presets_dir"], "with-orgs", loadout_orgs=["myorg"])
+        _make_registry(setup["registry_path"], [])
+        mocker.patch(
+            "devbox.bootstrap.run_loadout",
+            side_effect=Exception("github ssh timeout"),
+        )
+        result = create_devbox(
+            "mybox",
+            "with-orgs",
+            registry_path=setup["registry_path"],
+            presets_dir=setup["presets_dir"],
+        )
+        assert result["status"] == DevboxStatus.INCOMPLETE
+        warnings = result["bootstrap_warnings"]
+        assert len(warnings) == 1
+        assert "loadout" in warnings[0]
+        assert "github ssh timeout" in warnings[0]
+
+    def test_clone_repos_failure_marks_incomplete(
+        self, setup: dict[str, Any], mocker: MockerFixture
+    ) -> None:
+        """A failed clone_repos should leave the devbox in INCOMPLETE state."""
+        mocker.patch(
+            "devbox.bootstrap.clone_repos",
+            side_effect=Exception("repo unreachable"),
+        )
+        result = create_devbox(
+            "mybox",
+            "test-preset",
+            registry_path=setup["registry_path"],
+            presets_dir=setup["presets_dir"],
+        )
+        assert result["status"] == DevboxStatus.INCOMPLETE
+        warnings = result["bootstrap_warnings"]
+        assert len(warnings) == 1
+        assert "repo clone" in warnings[0]
+        assert "repo unreachable" in warnings[0]
+
+    def test_both_failures_collected(self, setup: dict[str, Any], mocker: MockerFixture) -> None:
+        """Both run_loadout and clone_repos failures should be reported together."""
+        _make_preset_file(setup["presets_dir"], "with-orgs", loadout_orgs=["myorg"])
+        _make_registry(setup["registry_path"], [])
+        mocker.patch("devbox.bootstrap.run_loadout", side_effect=Exception("e1"))
+        mocker.patch("devbox.bootstrap.clone_repos", side_effect=Exception("e2"))
+        result = create_devbox(
+            "mybox",
+            "with-orgs",
+            registry_path=setup["registry_path"],
+            presets_dir=setup["presets_dir"],
+        )
+        assert result["status"] == DevboxStatus.INCOMPLETE
+        assert len(result["bootstrap_warnings"]) == 2
+
+    def test_happy_path_returns_empty_warnings(self, setup: dict[str, Any]) -> None:
+        """A successful create returns READY with an empty bootstrap_warnings list."""
+        result = create_devbox(
+            "mybox",
+            "test-preset",
+            registry_path=setup["registry_path"],
+            presets_dir=setup["presets_dir"],
+        )
+        assert result["status"] == DevboxStatus.READY
+        assert result["bootstrap_warnings"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -855,6 +927,68 @@ class TestRefreshDevbox:
                 presets_dir=presets_dir,
             )
         mock_brew.assert_not_called()
+
+    def test_incomplete_status_repairs_then_proceeds(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Refresh on INCOMPLETE box runs run_loadout/clone_repos first."""
+        presets_dir = tmp_path / "presets"
+        presets_dir.mkdir()
+        _make_preset_file(presets_dir, "test-preset", loadout_orgs=["myorg"])
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [_entry("mybox", status=DevboxStatus.INCOMPLETE)])
+        mock_run_loadout = mocker.patch("devbox.bootstrap.run_loadout")
+        mock_clone_repos = mocker.patch("devbox.bootstrap.clone_repos")
+        mocker.patch("devbox.bootstrap.refresh_dotfiles")
+
+        refresh_devbox("mybox", registry_path=registry_path, presets_dir=presets_dir)
+
+        mock_run_loadout.assert_called_once()
+        mock_clone_repos.assert_called_once()
+        # Status should be promoted to READY after successful repair
+        from devbox.registry import find_entry
+
+        updated = find_entry("mybox", registry_path)
+        assert updated is not None
+        assert updated.status == DevboxStatus.READY
+
+    def test_incomplete_repair_failure_aborts_refresh(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """If repair clones still fail, refresh aborts before refresh_dotfiles."""
+        presets_dir = tmp_path / "presets"
+        presets_dir.mkdir()
+        _make_preset_file(presets_dir, "test-preset", loadout_orgs=["myorg"])
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [_entry("mybox", status=DevboxStatus.INCOMPLETE)])
+        mocker.patch(
+            "devbox.bootstrap.run_loadout",
+            side_effect=Exception("still throttled"),
+        )
+        mocker.patch("devbox.bootstrap.clone_repos")
+        mock_refresh_dotfiles = mocker.patch("devbox.bootstrap.refresh_dotfiles")
+
+        with pytest.raises(DevboxError, match="Repair failed"):
+            refresh_devbox("mybox", registry_path=registry_path, presets_dir=presets_dir)
+        mock_refresh_dotfiles.assert_not_called()
+        # Status should remain INCOMPLETE
+        from devbox.registry import find_entry
+
+        updated = find_entry("mybox", registry_path)
+        assert updated is not None
+        assert updated.status == DevboxStatus.INCOMPLETE
+
+    def test_ready_status_skips_repair(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """READY refresh should not invoke run_loadout / clone_repos repair path."""
+        registry_path, presets_dir = self._setup(tmp_path, loadout_orgs=["myorg"])
+        mock_run_loadout = mocker.patch("devbox.bootstrap.run_loadout")
+        mock_clone_repos = mocker.patch("devbox.bootstrap.clone_repos")
+        mocker.patch("devbox.bootstrap.refresh_dotfiles")
+
+        refresh_devbox("mybox", registry_path=registry_path, presets_dir=presets_dir)
+
+        mock_run_loadout.assert_not_called()
+        mock_clone_repos.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -233,6 +233,7 @@ class TestModels:
     def test_devbox_status_values(self) -> None:
         assert DevboxStatus.CREATING.value == "creating"
         assert DevboxStatus.READY.value == "ready"
+        assert DevboxStatus.INCOMPLETE.value == "incomplete"
         assert DevboxStatus.NUKING.value == "nuking"
 
     def test_registry_entry_defaults(self) -> None:


### PR DESCRIPTION
## Summary

Closes a recovery gap when `devbox create` hits transient GitHub SSH throttling: the box used to be marked **ready** even when `run_loadout` and/or `clone_repos` had failed, leaving `~/.dotfiles` missing and a subsequent `devbox refresh` crashing with `FileNotFoundError`. Now we track the failures, surface them clearly, and let `refresh` actually repair the box.

## Changes

- **Registry**: new `DevboxStatus.INCOMPLETE` between `READY` and `NUKING`.
- **`create_devbox`**: collects `bootstrap_warnings` from `run_loadout` / `clone_repos` exceptions and finalizes status as `INCOMPLETE` when any are present (else `READY`). Warnings are returned in the result dict.
- **CLI `create` / `rebuild`**: when warnings are present, print a yellow summary listing each failure and the recovery hint:
  > Some bootstrap steps failed (often GitHub SSH throttling). Wait a few minutes, then run `devbox refresh <name>` to retry.
- **`refresh_devbox`**: now accepts `INCOMPLETE` in addition to `READY`. On `INCOMPLETE` it re-runs `run_loadout` and `clone_repos` (both idempotent) before the normal refresh logic, and promotes the box to `READY` on success. If repair still fails (window not closed), raises a clear `DevboxError` instead of letting `refresh_dotfiles` trip on the missing `~/.dotfiles`.
- **CLI `refresh --all`**: includes `INCOMPLETE` boxes.
- **CLI `list`**: new yellow `incomplete` status icon.

## Why this matters

Real-world failure mode that triggered this: creating a new devbox immediately after pushing/pulling on the host. GitHub SYN-throttles port 22 from a single IP after a burst of connections (host push + inside-devbox loadout clones + brew clone + preset repos). Symptoms:

```
GitHub SSH connection error — skipping remaining clones
Loadout failed (non-fatal): Failed to clone dotfiles after retries: dotfiles
GitHub SSH connection error — skipping remaining clones
Repo setup failed (non-fatal): Failed to clone after retries: ...
✓ Devbox equinox created successfully    <-- misleading
  Connect: ssh dx-equinox

$ devbox refresh equinox
✗ FileNotFoundError: '/Users/dx-equinox/.dotfiles/loadout-build-...'
```

The intentional fail-fast on connection errors (lines 41-42 of `bootstrap.py`) stays — retrying immediately just burns the rate limit. The fix is purely about visibility and recovery.

## Test plan

- [x] `pytest` — 614 pass (7 new), 1 skipped, coverage 87.43%
- [x] `ruff check` — clean
- [x] `mypy --strict` — clean
- [ ] Manual: `devbox create` against a healthy box → status `ready`, no warnings (existing behavior unchanged)
- [ ] Manual: `devbox refresh` on `ready` box → no repair, normal flow (existing behavior unchanged)
- [ ] Manual: simulate throttle → status `incomplete`, warning summary printed, then `devbox refresh` repairs and promotes to `ready`