### PR TITLE
fix: warm up sudo before rebuild to prevent invisible timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `devbox rebuild` now warms up sudo (and 1Password when the preset has `op://` env vars) before the spinner starts, matching `create` and `nuke`. Previously, the first sudo call inside the rebuild was hidden by the spinner and timed out at 30s with a cryptic `Failed to set ownership on /Users/dx-* — timed out` error. New `preflight_rebuild` helper shares the warmup logic with `preflight_devbox` via a private `_preflight_system`.
+
 ### Security
 - Pin GitHub Actions to full commit SHAs
 - Add missing secret patterns to .gitignore

--- a/src/devbox/cli.py
+++ b/src/devbox/cli.py
@@ -96,6 +96,13 @@ def create(name: str, preset: str | None, dry_run: bool) -> None:
 def rebuild(name: str) -> None:
     """Tear down and recreate an existing devbox."""
     try:
+        # Preflight runs outside the spinner so sudo / 1Password prompts
+        # are visible. Without this the first sudo call inside the rebuild
+        # hangs invisibly behind the spinner and times out.
+        console.print(f"[bold]Preparing rebuild of {name!r}...[/bold]")
+        from devbox.core import preflight_rebuild
+
+        preflight_rebuild(name)
         with console.status(f"[bold]Rebuilding devbox {name!r}..."):
             result = rebuild_devbox(name)
         warnings = result.get("bootstrap_warnings") or []

--- a/src/devbox/core.py
+++ b/src/devbox/core.py
@@ -24,7 +24,7 @@ from devbox.bootstrap import bootstrap_user
 from devbox.exceptions import DevboxError
 from devbox.health import format_last_seen, get_health, read_heartbeat
 from devbox.naming import DX_PREFIX, validate_name
-from devbox.presets import load_preset
+from devbox.presets import Preset, load_preset
 from devbox.registry import (
     DevboxStatus,
     RegistryEntry,
@@ -86,24 +86,14 @@ class _CompensationStack:
         return errors
 
 
-def preflight_devbox(
-    name: str,
-    preset: str,
-    registry_path: Path | None = None,
-    presets_dir: Path | None = None,
-) -> None:
-    """Run preflight checks and warm up sudo before create.
+def _preflight_system(preset_obj: Preset) -> None:
+    """Check system prereqs and warm up sudo / 1Password.
 
-    Called outside the spinner so interactive prompts (sudo password) are visible.
+    Shared by ``preflight_devbox`` (create) and ``preflight_rebuild``.
+    Must be called outside the CLI spinner so interactive prompts
+    (sudo password, 1Password biometric) are visible to the user.
     Raises :exc:`DevboxError` on failure.
     """
-    validate_name(name)
-    preset_obj = load_preset(preset, presets_dir)
-
-    existing = find_entry(name, registry_path)
-    if existing is not None:
-        raise DevboxError(f"Devbox {name!r} already exists (status: {existing.status})")
-
     if not sshd.is_remote_login_enabled():
         raise DevboxError(
             "Remote Login (sshd) is not enabled. "
@@ -124,6 +114,51 @@ def preflight_devbox(
     result = subprocess.run(["sudo", "-v"], timeout=60)  # noqa: S607
     if result.returncode != 0:
         raise DevboxError("sudo authentication failed")
+
+
+def preflight_devbox(
+    name: str,
+    preset: str,
+    registry_path: Path | None = None,
+    presets_dir: Path | None = None,
+) -> None:
+    """Run preflight checks and warm up sudo before create.
+
+    Called outside the spinner so interactive prompts (sudo password) are visible.
+    Raises :exc:`DevboxError` on failure.
+    """
+    validate_name(name)
+    preset_obj = load_preset(preset, presets_dir)
+
+    existing = find_entry(name, registry_path)
+    if existing is not None:
+        raise DevboxError(f"Devbox {name!r} already exists (status: {existing.status})")
+
+    _preflight_system(preset_obj)
+
+
+def preflight_rebuild(
+    name: str,
+    registry_path: Path | None = None,
+    presets_dir: Path | None = None,
+) -> None:
+    """Run preflight checks and warm up sudo before rebuild.
+
+    Same as :func:`preflight_devbox` but expects the registry entry to
+    exist (rebuild fails on missing entries; create fails on duplicates).
+    Without this warmup the rebuild's first ``sudo`` call is hidden by
+    the spinner and times out at 30 s — see issue history.
+
+    Raises :exc:`DevboxError` on failure.
+    """
+    validate_name(name)
+
+    entry = find_entry(name, registry_path)
+    if entry is None:
+        raise DevboxError(f"Devbox {name!r} not found in registry")
+
+    preset_obj = load_preset(entry.preset, presets_dir)
+    _preflight_system(preset_obj)
 
 
 def create_devbox(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,6 +253,7 @@ class TestNukeDryRun:
 
 class TestRebuildCommand:
     def test_happy_path(self, runner: CliRunner, mocker: MockerFixture) -> None:
+        mocker.patch("devbox.core.preflight_rebuild")
         mocker.patch("devbox.cli.rebuild_devbox")
         mocker.patch("devbox.cli.console")
 
@@ -260,7 +261,19 @@ class TestRebuildCommand:
 
         assert result.exit_code == 0
 
+    def test_calls_preflight_before_rebuild(self, runner: CliRunner, mocker: MockerFixture) -> None:
+        """Preflight runs outside the spinner so sudo prompts are visible."""
+        mock_preflight = mocker.patch("devbox.core.preflight_rebuild")
+        mock_rebuild = mocker.patch("devbox.cli.rebuild_devbox")
+        mocker.patch("devbox.cli.console")
+
+        runner.invoke(cli, ["rebuild", "mybox"])
+
+        mock_preflight.assert_called_once_with("mybox")
+        mock_rebuild.assert_called_once_with("mybox")
+
     def test_calls_core_with_name(self, runner: CliRunner, mocker: MockerFixture) -> None:
+        mocker.patch("devbox.core.preflight_rebuild")
         mock_rebuild = mocker.patch("devbox.cli.rebuild_devbox")
         mocker.patch("devbox.cli.console")
 
@@ -271,6 +284,7 @@ class TestRebuildCommand:
     def test_success_output_mentions_rebuilt(
         self, runner: CliRunner, mocker: MockerFixture
     ) -> None:
+        mocker.patch("devbox.core.preflight_rebuild")
         mocker.patch("devbox.cli.rebuild_devbox")
         mock_console = mocker.patch("devbox.cli.console")
 
@@ -279,6 +293,22 @@ class TestRebuildCommand:
         printed = " ".join(str(c) for c in mock_console.print.call_args_list)
         assert "rebuilt" in printed
         assert "mybox" in printed
+
+    def test_preflight_failure_skips_rebuild(
+        self, runner: CliRunner, mocker: MockerFixture
+    ) -> None:
+        """If preflight raises, rebuild_devbox should not be invoked."""
+        mocker.patch(
+            "devbox.core.preflight_rebuild",
+            side_effect=DevboxError("not found"),
+        )
+        mock_rebuild = mocker.patch("devbox.cli.rebuild_devbox")
+        mocker.patch("devbox.cli.console")
+
+        result = runner.invoke(cli, ["rebuild", "mybox"])
+
+        assert result.exit_code == 1
+        mock_rebuild.assert_not_called()
 
     def test_devbox_error_exits_1(self, runner: CliRunner, mocker: MockerFixture) -> None:
         mocker.patch(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -708,6 +708,102 @@ class TestNukeDevbox:
 # ---------------------------------------------------------------------------
 
 
+class TestPreflightRebuild:
+    """preflight_rebuild validates the entry exists and warms up sudo."""
+
+    def test_missing_entry_raises(self, tmp_path: Path) -> None:
+        from devbox.core import preflight_rebuild
+
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [])
+        with pytest.raises(DevboxError, match="not found"):
+            preflight_rebuild("missing", registry_path=registry_path)
+
+    def test_invalid_name_raises(self, tmp_path: Path) -> None:
+        from devbox.core import preflight_rebuild
+
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [])
+        with pytest.raises(ValueError, match="kebab-case"):
+            preflight_rebuild("Bad_Name", registry_path=registry_path)
+
+    def test_warms_up_sudo(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """Sudo warmup runs even when no op:// refs are present."""
+        from devbox.core import preflight_rebuild
+
+        presets_dir = tmp_path / "presets"
+        presets_dir.mkdir()
+        _make_preset_file(presets_dir, "test-preset")
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [_entry("mybox", status=DevboxStatus.READY)])
+
+        mocker.patch("devbox.core.sshd.is_remote_login_enabled", return_value=True)
+        mock_run = mocker.patch(
+            "devbox.core.subprocess.run",
+            return_value=mocker.MagicMock(returncode=0),
+        )
+
+        preflight_rebuild("mybox", registry_path=registry_path, presets_dir=presets_dir)
+
+        sudo_calls = [c for c in mock_run.call_args_list if c.args[0] == ["sudo", "-v"]]
+        assert len(sudo_calls) == 1
+
+    def test_op_warmup_when_op_refs_present(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """A preset with op:// env_vars triggers an op whoami warmup."""
+        from devbox.core import preflight_rebuild
+
+        presets_dir = tmp_path / "presets"
+        presets_dir.mkdir()
+        _make_preset_file(
+            presets_dir,
+            "test-preset",
+            env_vars={"TOKEN": "op://vault/item/field"},
+        )
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [_entry("mybox", status=DevboxStatus.READY)])
+
+        mocker.patch("devbox.core.sshd.is_remote_login_enabled", return_value=True)
+        mock_run = mocker.patch(
+            "devbox.core.subprocess.run",
+            return_value=mocker.MagicMock(returncode=0),
+        )
+
+        preflight_rebuild("mybox", registry_path=registry_path, presets_dir=presets_dir)
+
+        op_calls = [c for c in mock_run.call_args_list if c.args[0] == ["op", "whoami"]]
+        assert len(op_calls) == 1
+
+    def test_sshd_disabled_raises(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        from devbox.core import preflight_rebuild
+
+        presets_dir = tmp_path / "presets"
+        presets_dir.mkdir()
+        _make_preset_file(presets_dir, "test-preset")
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [_entry("mybox", status=DevboxStatus.READY)])
+
+        mocker.patch("devbox.core.sshd.is_remote_login_enabled", return_value=False)
+        with pytest.raises(DevboxError, match="Remote Login"):
+            preflight_rebuild("mybox", registry_path=registry_path, presets_dir=presets_dir)
+
+    def test_sudo_failure_raises(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        from devbox.core import preflight_rebuild
+
+        presets_dir = tmp_path / "presets"
+        presets_dir.mkdir()
+        _make_preset_file(presets_dir, "test-preset")
+        registry_path = tmp_path / "registry.json"
+        _make_registry(registry_path, [_entry("mybox", status=DevboxStatus.READY)])
+
+        mocker.patch("devbox.core.sshd.is_remote_login_enabled", return_value=True)
+        mocker.patch(
+            "devbox.core.subprocess.run",
+            return_value=mocker.MagicMock(returncode=1),
+        )
+        with pytest.raises(DevboxError, match="sudo authentication failed"):
+            preflight_rebuild("mybox", registry_path=registry_path, presets_dir=presets_dir)
+
+
 class TestRebuildDevbox:
     def test_happy_path(self, tmp_path: Path, mocker: MockerFixture) -> None:
         presets_dir = tmp_path / "presets"


### PR DESCRIPTION
## Summary

`devbox rebuild` was timing out at 30s with a cryptic `Failed to set ownership on /Users/dx-* — timed out` error whenever sudo credentials had expired. The first sudo call inside the rebuild flow (`_sudo_chown`) was running behind the spinner, so the password prompt was invisible and the call hung until timeout.

`create` and `nuke` already do a sudo (and 1Password) warmup *outside* the spinner. This adds the same pattern to `rebuild`.

## Changes

- **`_preflight_system(preset_obj)`**: private helper that runs the shared system-level checks and warmups (sshd enabled → `op whoami` if preset has `op://` refs → `sudo -v`). Extracted from `preflight_devbox`.
- **`preflight_devbox`**: same behavior, now delegates the system part to `_preflight_system` after its create-specific "no duplicate entry" check.
- **`preflight_rebuild(name, ...)`**: new entry point. Validates that the registry entry exists (vs. create's "must not exist" check), then calls `_preflight_system`.
- **CLI `rebuild`**: calls `preflight_rebuild` before entering the spinner, mirroring how `create` calls `preflight_devbox`.

## Why this matters

Real failure mode that surfaced this bug: a few minutes after `sudo -v`, credentials lapse, then `devbox rebuild` looks like it just hangs. Instead of the user seeing a password prompt, they see a spinner and eventually:

```
✗ Failed to set ownership on /Users/dx-equinox: timed out
```

The actual problem (sudo wanting a password) is hidden by `subprocess.run(..., capture_output=True)` plus the rich spinner. Same UX hazard that `create` was originally written to avoid.

## Test plan

- [x] `pytest` — 606 pass / 1 skipped
- [x] `ruff format --check` clean
- [x] `ruff check` clean
- [x] `mypy --strict` clean (22 source files)
- [x] 6 new core tests for `preflight_rebuild` (missing entry, invalid name, sudo warmup, op warmup, sshd disabled, sudo failure)
- [x] 1 new CLI test verifying preflight runs before `rebuild_devbox` and that preflight failure skips the rebuild call
- [ ] Manual: let sudo creds lapse, then `devbox rebuild <name>` — should now prompt for password before the spinner starts